### PR TITLE
GET each Streak pipeline individually when syncing

### DIFF
--- a/app/jobs/update_from_streak_job.rb
+++ b/app/jobs/update_from_streak_job.rb
@@ -10,12 +10,10 @@ class UpdateFromStreakJob < ApplicationJob
       model.included_modules.include? Streakable
     end
 
-    boxes = StreakClient::Box.all
-
     relationships_to_create = {}
 
     streakable_models.each do |model|
-      model_boxes = boxes.select { |b| b[:pipeline_key] == model.pipeline_key }
+      model_boxes = StreakClient::Box.all_in_pipeline(model.pipeline_key)
 
       relationships_to_create[model] = {}
 


### PR DESCRIPTION
We've hit the point where Streak has started throwing 500s and 503s when calling GET /v1/boxes -- probably a result of having too many boxes.

This change makes it so our sync logic retrieves pipelines one at a time, hopefully fixing the issue with getting errors from their API.