### PR TITLE
Camelize params passed into StreakClient

### DIFF
--- a/app/models/concerns/streakable.rb
+++ b/app/models/concerns/streakable.rb
@@ -109,7 +109,7 @@ module Streakable
     StreakClient::Box.update(
       get_streak_key,
       notes: notes,
-      linkedBoxKeys: linked_streak_box_keys
+      linked_box_keys: linked_streak_box_keys
     )
 
     update_all_streak_fields

--- a/lib/streak_client.rb
+++ b/lib/streak_client.rb
@@ -26,6 +26,8 @@ module StreakClient
 
       headers["Authorization"] = construct_http_auth_header(@api_key, "")
 
+      params = transform_params(params)
+
       case method
       when :post
         headers['Content-Type'] = 'application/json'
@@ -46,6 +48,12 @@ module StreakClient
 
     def construct_http_auth_header(username, password)
       "Basic #{Base64.strict_encode64(username + ':' + password)}"
+    end
+
+    def transform_params(params)
+      params
+        .clone
+        .deep_transform_keys { |k| k.to_s.camelize(:lower) }
     end
 
     def parse(response)

--- a/lib/streak_client/box.rb
+++ b/lib/streak_client/box.rb
@@ -14,11 +14,12 @@ module StreakClient
 
     # params is a hash of key value pairs for fields to update in Streak.
     #
-    # Accepted keys: :name, :notes, :stageKey, :followerKeys, and :linkedBoxKeys
+    # Accepted keys: :name, :notes, :stage_key, :follower_keys, and
+    # :linked_box_keys
     #
-    # :names and :notes are strings. :stageKey is the key of the stage to change
-    # the box to. :followerKeys and :linkedBoxKeys are both arrays of strings
-    # representing keys on Streak.
+    # :names and :notes are strings. :stage_key is the key of the stage to
+    # change the box to. :follower_keys and :linked_box_keys are both arrays of
+    # strings representing keys on Streak.
     #
     # See https://www.streak.com/api/#editbox
     def self.update(box_key, params)

--- a/lib/tasks/outreach/teacher_emails/associate_teachers.rake
+++ b/lib/tasks/outreach/teacher_emails/associate_teachers.rake
@@ -33,12 +33,12 @@ task associate_teachers: :environment do
 
       StreakClient::Box.update(
         teacher[:key],
-        linkedBoxKeys: [school[:key]],
+        linked_box_keys: [school[:key]],
         notes: ''
       )
       StreakClient::Box.update(
         school[:key],
-        stageKey: school_teacher_boxes_added_stage_key
+        stage_key: school_teacher_boxes_added_stage_key
       )
     end
   end

--- a/spec/support/shared_examples/streakable.rb
+++ b/spec/support/shared_examples/streakable.rb
@@ -111,7 +111,7 @@ RSpec.shared_examples "Streakable" do
                                       .with(
                                         streak_key,
                                         notes: notes,
-                                        linkedBoxKeys: linked_box_keys
+                                        linked_box_keys: linked_box_keys
                                       )
   end
 


### PR DESCRIPTION
This change makes it so we can pass params with snake_case keys into
StreakClient and have them transformed for Streak's API.