### PR TITLE
Create initial version of hackbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,4 +65,19 @@ CLOUD9_PASSWORD
 # Keys for school and teacher outreach pipelines
 STREAK_OUTREACH_SCHOOL_PIPELINE_KEY
 STREAK_OUTREACH_TEACHER_PIPELINE_KEY
+
+# For Slack authentication
+SLACK_CLIENT_ID
+SLACK_CLIENT_SECRET
 ```
+
+## Other Setup
+
+Dumping this stuff here for lack of a better place.
+
+### Setting up the Slack App
+
+1. Create a new Slack app on Slack
+2. Create one (and only one) bot user and set "Always Show My Bot as Online" to "On"
+3. Click "Event Subscriptions" on the sidebar in the left and set the request URL to `HOSTNAME/v1/hackbot/webhook`, replacing `HOSTNAME` with your actual hostname.
+4. Subscribe to the following bot events: `message.channels`, `message.im`, `message.groups`, `message.mpim`

--- a/app/controllers/v1/hackbot/auth_controller.rb
+++ b/app/controllers/v1/hackbot/auth_controller.rb
@@ -1,0 +1,25 @@
+class V1::Hackbot::AuthController < ApplicationController
+  CLIENT_ID = Rails.application.secrets.slack_client_id
+  CLIENT_SECRET = Rails.application.secrets.slack_client_secret
+
+  def create
+    code = params[:code]
+
+    resp = SlackClient::Oauth.access(CLIENT_ID, CLIENT_SECRET, code)
+
+    unless resp[:ok]
+      return render status: 403
+    end
+
+    if ::Hackbot::Team.exists?(team_id: resp[:team_id])
+      return render status: 400
+    else
+      ::Hackbot::Team.create(
+        team_id: resp[:team_id],
+        team_name: resp[:team_name],
+        bot_user_id: resp[:bot][:bot_user_id],
+        bot_access_token: resp[:bot][:bot_access_token]
+      )
+    end
+  end
+end

--- a/app/controllers/v1/hackbot/webhook_controller.rb
+++ b/app/controllers/v1/hackbot/webhook_controller.rb
@@ -1,0 +1,16 @@
+class V1::Hackbot::WebhookController < ApplicationController
+  def callback
+    # See https://api.slack.com/events/url_verification
+    if params[:type] == 'url_verification'
+      return render plain: params[:challenge]
+    elsif params[:type] != 'event_callback'
+      return render status: :not_implemented
+    end
+
+    slack_team = ::Hackbot::Team.find_by(team_id: params[:team_id])
+
+    ::Hackbot::Dispatcher.new.handle(params[:event], slack_team)
+
+    render status: 200
+  end
+end

--- a/app/models/hackbot.rb
+++ b/app/models/hackbot.rb
@@ -1,0 +1,5 @@
+module Hackbot
+  def self.table_name_prefix
+    'hackbot_'
+  end
+end

--- a/app/models/hackbot/conversation.rb
+++ b/app/models/hackbot/conversation.rb
@@ -1,0 +1,50 @@
+class Hackbot::Conversation < ApplicationRecord
+  after_initialize :default_values
+
+  belongs_to :team, foreign_key: 'hackbot_team_id', class_name: ::Hackbot::Team
+
+  validates_presence_of :team, :state
+
+  def self.should_start?(event)
+    raise NotImplementedError
+  end
+
+  def is_part_of_convo?(event)
+    # Don't react to events that we cause
+    event[:user] != self.team.bot_user_id
+  end
+
+  def handle(event)
+    next_state = send(self.state, event)
+
+    if next_state.is_a? Symbol
+      self.state = next_state
+    else
+      self.state = :finish
+    end
+
+    if self.state == :finish
+      send(:finish, event)
+    end
+  end
+
+  protected
+
+  def start(event)
+    raise notImplementedError
+  end
+
+  def finish(event)
+  end
+
+  def send_msg(channel, text)
+    SlackClient::Chat.send_msg(channel, text, self.team.bot_access_token, as_user: true)
+  end
+
+  private
+
+  def default_values
+    self.state ||= :start
+    self.data ||= {}
+  end
+end

--- a/app/models/hackbot/conversations/attendance.rb
+++ b/app/models/hackbot/conversations/attendance.rb
@@ -1,0 +1,29 @@
+class Hackbot::Conversations::Attendance < Hackbot::Conversations::Channel
+  def self.should_start?(event)
+    event[:type] == 'message' && event[:text] =~ /^attendance/
+  end
+
+  def start(event)
+    msg_channel "Another week, another time for attendance! Say 'go' when you're ready to begin."
+
+    :wait_for_go
+  end
+
+  def wait_for_go(event)
+    return :wait_for_go unless event[:type] == 'message'
+
+    if event[:text] =~ /^(go|start|begin)$/i
+      msg_channel "Sweet, let's do this! How many people came to your last meeting?"
+
+      return :get_attendance
+    end
+
+    msg_channel "Huh, I didn't quite get that. Can you try again?"
+
+    :wait_for_go
+  end
+
+  def get_attendance(event)
+    msg_channel "Holy crap! #{event[:text]} is a huge number of people! Great work."
+  end
+end

--- a/app/models/hackbot/conversations/channel.rb
+++ b/app/models/hackbot/conversations/channel.rb
@@ -1,0 +1,18 @@
+# Channel is a conversation that is limited to a single channel on Slack. Most
+# conversations will inherit from this class.
+class Hackbot::Conversations::Channel < Hackbot::Conversation
+  def is_part_of_convo?(event)
+    event[:channel] == self.data['channel'] && super
+  end
+
+  def handle(event)
+    self.data['channel'] = event[:channel]
+    super
+  end
+
+  protected
+
+  def msg_channel(text)
+    send_msg(self.data['channel'], text)
+  end
+end

--- a/app/models/hackbot/conversations/mention.rb
+++ b/app/models/hackbot/conversations/mention.rb
@@ -1,0 +1,21 @@
+class Hackbot::Conversations::Mention < Hackbot::Conversations::Channel
+  def self.should_start?(event)
+    event[:type] == 'message' && event[:text] =~ /hackbot/
+  end
+
+  def start(event)
+    msg_channel "Did someone mention me?"
+
+    :wait_for_resp
+  end
+
+  def wait_for_resp(event)
+    if event[:text] =~ /^(no|nope|nah|negative)$/i
+      msg_channel "Oh, I see... :slightly_frowning_face:"
+    elsif event[:text] =~ /^(yes|yeah|yah|ya|yup)$/i
+      msg_channel "Oh my! I'm so glad to hear... I was getting a little worried for a moment there."
+    end
+
+    :finish
+  end
+end

--- a/app/models/hackbot/dispatcher.rb
+++ b/app/models/hackbot/dispatcher.rb
@@ -1,0 +1,26 @@
+class Hackbot::Dispatcher
+  CONVERSATION_TYPES = [
+    Hackbot::Conversations::Attendance,
+    Hackbot::Conversations::Mention
+  ]
+
+  def handle(event, slack_team)
+    wranglers = convos_needing_handling(event)
+
+    if wranglers.size > 0
+      return wranglers.each { |w| w.handle(event); w.save! }
+    end
+
+    to_create = CONVERSATION_TYPES.select { |c| c.should_start? event }
+    created = to_create.map { |c| c.new(team: slack_team) }
+
+    created.map { |c| c.handle(event); c.save! }
+  end
+
+  protected
+
+  def convos_needing_handling(event)
+    Hackbot::Conversation.where.not(state: :finish)
+      .select { |c| c.is_part_of_convo? event }
+  end
+end

--- a/app/models/hackbot/team.rb
+++ b/app/models/hackbot/team.rb
@@ -1,0 +1,6 @@
+class Hackbot::Team < ApplicationRecord
+  validates_presence_of :team_id, :team_name, :bot_user_id, :bot_access_token
+  validates_uniqueness_of :team_id, :bot_user_id, :bot_access_token
+
+  has_many :conversations, foreign_key: 'hackbot_team_id', class_name: ::Hackbot::Conversation
+end

--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,8 @@ machine:
     CLOUD9_TEAM_NAME: fake_team_name
     STREAK_OUTREACH_SCHOOL_PIPELINE_KEY: schools
     STREAK_OUTREACH_TEACHER_PIPELINE_KEY: teachers
+    SLACK_CLIENT_ID: fake_client_id
+    SLACK_CLIENT_SECRET: fake_client_secret
 
 deployment:
   production:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,10 @@ Rails.application.routes.draw do
     post 'cloud9/send_invite'
 
     resources :clubs
+
+    namespace :hackbot do
+      post 'auth', to: 'auth#create'
+      post 'webhook', to: 'webhook#callback'
+    end
   end
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -24,6 +24,9 @@ common: &common
   streak_outreach_school_pipeline_key: <%= ENV.fetch("STREAK_OUTREACH_SCHOOL_PIPELINE_KEY") %>
   streak_outreach_teacher_pipeline_key: <%= ENV.fetch("STREAK_OUTREACH_TEACHER_PIPELINE_KEY") %>
 
+  slack_client_id: "<%= ENV.fetch('SLACK_CLIENT_ID') %>"
+  slack_client_secret: "<%= ENV.fetch('SLACK_CLIENT_SECRET') %>"
+
 development:
   <<: *common
   secret_key_base: 6d02f9126a44347e07442fddf774b6a434a85b86e23629eab947c9c101b8aa878ad8fe5dadba26a3341f1a16f480068ae5234861cb7b913f526a0e96a21fcc7d

--- a/db/migrate/20161231005311_create_hackbot_teams.rb
+++ b/db/migrate/20161231005311_create_hackbot_teams.rb
@@ -1,0 +1,13 @@
+class CreateHackbotTeams < ActiveRecord::Migration[5.0]
+  def change
+    create_table :hackbot_teams do |t|
+      t.text :team_id
+      t.text :team_name
+
+      t.text :bot_user_id
+      t.text :bot_access_token
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170101004638_create_hackbot_conversations.rb
+++ b/db/migrate/20170101004638_create_hackbot_conversations.rb
@@ -1,0 +1,12 @@
+class CreateHackbotConversations < ActiveRecord::Migration[5.0]
+  def change
+    create_table :hackbot_conversations do |t|
+      t.text :type
+      t.references :hackbot_team
+      t.text :state
+      t.json :data
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161119154945) do
+ActiveRecord::Schema.define(version: 20170101004638) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,25 @@ ActiveRecord::Schema.define(version: 20161119154945) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
+  end
+
+  create_table "hackbot_conversations", force: :cascade do |t|
+    t.text     "type"
+    t.integer  "hackbot_team_id"
+    t.text     "state"
+    t.json     "data"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+    t.index ["hackbot_team_id"], name: "index_hackbot_conversations_on_hackbot_team_id", using: :btree
+  end
+
+  create_table "hackbot_teams", force: :cascade do |t|
+    t.text     "team_id"
+    t.text     "team_name"
+    t.text     "bot_user_id"
+    t.text     "bot_access_token"
+    t.datetime "created_at",       null: false
+    t.datetime "updated_at",       null: false
   end
 
   create_table "leaders", force: :cascade do |t|

--- a/lib/slack_client.rb
+++ b/lib/slack_client.rb
@@ -1,0 +1,23 @@
+require "slack_client/chat"
+require "slack_client/oauth"
+
+module SlackClient
+  @api_base = "https://www.slack.com/api"
+
+  class << self
+    attr_accessor :api_base
+
+    def rpc_url(method)
+      @api_base + "/" + method
+    end
+
+    def rpc(method, access_token, args={}, headers={})
+      args[:token] ||= access_token
+
+      resp = RestClient::Request.execute(method: :post, url: rpc_url(method),
+                                         headers: headers, payload: args)
+
+      JSON.parse(resp.body, symbolize_names: true)
+    end
+  end
+end

--- a/lib/slack_client/chat.rb
+++ b/lib/slack_client/chat.rb
@@ -1,0 +1,10 @@
+module SlackClient
+  module Chat
+    def self.send_msg(channel, text, access_token, extra_params={})
+      extra_params[:channel] ||= channel
+      extra_params[:text] ||= text
+
+      SlackClient.rpc('chat.postMessage', access_token, extra_params)
+    end
+  end
+end

--- a/lib/slack_client/oauth.rb
+++ b/lib/slack_client/oauth.rb
@@ -1,0 +1,14 @@
+module SlackClient
+  module Oauth
+    def self.access(client_id, client_secret, code, redirect_uri=nil)
+      SlackClient.rpc(
+        'oauth.access',
+        nil,
+        client_id: client_id,
+        client_secret: client_secret,
+        code: code,
+        redirect_uri: redirect_uri
+      )
+    end
+  end
+end

--- a/spec/models/hackbot/conversation_spec.rb
+++ b/spec/models/hackbot/conversation_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe Hackbot::Conversation, type: :model do
+  it { should have_db_column :type }
+  it { should have_db_column :hackbot_team_id }
+  it { should have_db_column :state }
+  it { should have_db_column :data }
+
+  it { should validate_presence_of :team }
+  it { should validate_presence_of :state }
+
+  it { should belong_to :team }
+end

--- a/spec/models/hackbot/team_spec.rb
+++ b/spec/models/hackbot/team_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Hackbot::Team, type: :model do
+  it { should have_db_column :team_id }
+  it { should have_db_column :team_name }
+  it { should have_db_column :bot_user_id }
+  it { should have_db_column :bot_access_token }
+
+  it { should validate_presence_of :team_id }
+  it { should validate_presence_of :team_name }
+  it { should validate_presence_of :bot_user_id }
+  it { should validate_presence_of :bot_access_token }
+
+  it { should validate_uniqueness_of :team_id }
+  it { should validate_uniqueness_of :bot_user_id }
+  it { should validate_uniqueness_of :bot_access_token }
+
+  it { should have_many :conversations }
+end


### PR DESCRIPTION
This pull request creates the initial version of `hackbot`, our friendly bot that we're going to use to collect attendance from clubs in 2017.

@paked: I'm going to merge this myself for now because you're not yet full-time on this project, but would love any feedback you have on how to improve this – I'm considering changing the "abstract" model for interactions from `Conversation` to `Interaction` and then having `Conversation` as a subclass that only deals with messages and I know there are many other things that can be improved (tests being one of them).