### PR TITLE
Fix bug preventing creation of CheckIn instances

### DIFF
--- a/app/models/check_in.rb
+++ b/app/models/check_in.rb
@@ -2,5 +2,5 @@ class CheckIn < ApplicationRecord
   belongs_to :club
   belongs_to :leader
 
-  validates :club, :leader, :meeting_date, :attendance, :notes, presence: true
+  validates :club, :leader, :meeting_date, :attendance, presence: true
 end

--- a/app/models/hackbot/conversations/check_in.rb
+++ b/app/models/hackbot/conversations/check_in.rb
@@ -115,7 +115,7 @@ module Hackbot
       def wait_for_notes(event)
         data['notes'] = event[:text] unless event[:text] =~ /^(no|nope|nah)$/i
 
-        CheckIn.create(
+        ::CheckIn.create(
           club: club(event),
           leader: leader(event),
           meeting_date: data['meeting_date'],

--- a/spec/models/check_in_spec.rb
+++ b/spec/models/check_in_spec.rb
@@ -14,5 +14,4 @@ RSpec.describe CheckIn, type: :model do
   it { should validate_presence_of :leader }
   it { should validate_presence_of :meeting_date }
   it { should validate_presence_of :attendance }
-  it { should validate_presence_of :notes }
 end


### PR DESCRIPTION
`notes` was a required field and would be `nil` when the user didn't have anything they wanted to send us.