### PR TITLE
Add method of determining a main Point of Contact

### DIFF
--- a/app/models/club.rb
+++ b/app/models/club.rb
@@ -31,6 +31,7 @@ class Club < ApplicationRecord
                 longitude: :longitude
 
   has_and_belongs_to_many :leaders
+  has_many :main_point_of_contact
   has_many :check_ins
 
   validates :name, presence: true

--- a/app/models/hackbot/conversations/check_in.rb
+++ b/app/models/hackbot/conversations/check_in.rb
@@ -4,8 +4,8 @@
 # See https://github.com/hackclub/api/issues/25.
 module Hackbot
   module Conversations
-    POSITIVE=/(yes|yeah|yup|mmhm|affirmative)/i
-    NEGATIVE=/(no|nope|nah|negative)/i
+    POSITIVE = /(yes|yeah|yup|mmhm|affirmative)/i
+    NEGATIVE = /(no|nope|nah|negative)/i
 
     # rubocop:disable Metrics/ClassLength
     class CheckIn < Hackbot::Conversations::Channel
@@ -15,8 +15,8 @@ module Hackbot
 
       def start(event)
         if ask_if_poc event
-          msg_channel "Before we start, I just want to ask if you would like to "\
-                      "be the main point of contact for your club?"
+          msg_channel 'Before we start, I just want to ask if you would like '\
+                      'to be the main point of contact for your club?'
 
           return :determine_poc
         end
@@ -28,6 +28,7 @@ module Hackbot
         :wait_for_meeting_confirmation
       end
 
+      # rubocop:disable Metrics/MethodLength
       def determine_poc(event)
         case event[:text]
         when POSITIVE
@@ -40,7 +41,8 @@ module Hackbot
 
           start(event)
         when NEGATIVE
-          msg_channel "Gotcha! I'll be in touch with another one of your co-leaders then :)"
+          msg_channel "Gotcha! I'll be in touch with another one of your "\
+                      'co-leaders then :)'
 
           :finish
         else
@@ -50,6 +52,7 @@ module Hackbot
           :determine_poc
         end
       end
+      # rubocop:enable Metrics/MethodLength
 
       # rubocop:disable Metrics/MethodLength
       def wait_for_meeting_confirmation(event)
@@ -163,7 +166,10 @@ module Hackbot
       private
 
       def ask_if_poc(event)
-        MainPointOfContact.where(club: club(event).id, leader: leader(event)).first.nil?
+        MainPointOfContact.find_by(
+          club: club(event),
+          leader: leader(event)
+        ).nil?
       end
 
       def integer?(str)

--- a/app/models/hackbot/conversations/check_in.rb
+++ b/app/models/hackbot/conversations/check_in.rb
@@ -21,8 +21,10 @@ module Hackbot
         end
 
         if ask_if_poc event
-          msg_channel 'Before we start, I just want to ask if you would like '\
-                      'to be the main point of contact for your club?'
+          msg_channel "Before we start, I'd just like to check if you want "\
+                      "to be your club's main point of contact. This means "\
+                      "that you'll be responsible for responding to me at the "\
+                      'end of each week.'
 
           return :determine_poc
         end

--- a/app/models/hackbot/conversations/check_in.rb
+++ b/app/models/hackbot/conversations/check_in.rb
@@ -29,7 +29,7 @@ module Hackbot
           return :determine_poc
         end
 
-        msg_channel "Did you have a club meeting this week?"
+        msg_channel 'Did you have a club meeting this week?'
 
         :wait_for_meeting_confirmation
       end

--- a/app/models/hackbot/conversations/check_in.rb
+++ b/app/models/hackbot/conversations/check_in.rb
@@ -13,7 +13,13 @@ module Hackbot
         event[:text] == 'check in'
       end
 
+      # rubocop:disable Metrics/MethodLength
       def start(event)
+        if data['asked_if_poc'].nil?
+          first_name = leader(event).name.split(' ').first
+          msg_channel "Hey #{first_name}!"
+        end
+
         if ask_if_poc event
           msg_channel 'Before we start, I just want to ask if you would like '\
                       'to be the main point of contact for your club?'
@@ -21,15 +27,16 @@ module Hackbot
           return :determine_poc
         end
 
-        first_name = leader(event).name.split(' ').first
-
-        msg_channel "Hey #{first_name}! Did you have a club meeting this week?"
+        msg_channel "Did you have a club meeting this week?"
 
         :wait_for_meeting_confirmation
       end
+      # rubocop:enable Metrics/MethodLength
 
       # rubocop:disable Metrics/MethodLength
       def determine_poc(event)
+        data['asked_if_poc'] = true
+
         case event[:text]
         when POSITIVE
           msg_channel "Awesome! Let's keep going then!"

--- a/app/models/main_point_of_contact.rb
+++ b/app/models/main_point_of_contact.rb
@@ -1,0 +1,7 @@
+class MainPointOfContact < ApplicationRecord
+  validates :leader, presence: true
+  validates :club, presence: true
+
+  belongs_to :leader
+  belongs_to :club
+end

--- a/db/migrate/20170216130836_create_main_point_of_contacts.rb
+++ b/db/migrate/20170216130836_create_main_point_of_contacts.rb
@@ -1,0 +1,10 @@
+class CreateMainPointOfContacts < ActiveRecord::Migration[5.0]
+  def change
+    create_table :main_point_of_contacts do |t|
+      t.references :club, foreign_key: true
+      t.references :leader, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170119233357) do
+ActiveRecord::Schema.define(version: 20170216130836) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,8 +21,10 @@ ActiveRecord::Schema.define(version: 20170119233357) do
     t.date     "meeting_date"
     t.integer  "attendance"
     t.text     "notes"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+    t.datetime "created_at",       null: false
+    t.datetime "updated_at",       null: false
+    t.text     "did_happen"
+    t.text     "failed_to_happen"
     t.index ["club_id"], name: "index_check_ins_on_club_id", using: :btree
     t.index ["leader_id"], name: "index_check_ins_on_leader_id", using: :btree
   end
@@ -114,6 +116,15 @@ ActiveRecord::Schema.define(version: 20170119233357) do
     t.index ["streak_key"], name: "index_letters_on_streak_key", using: :btree
   end
 
+  create_table "main_point_of_contacts", force: :cascade do |t|
+    t.integer  "club_id"
+    t.integer  "leader_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["club_id"], name: "index_main_point_of_contacts_on_club_id", using: :btree
+    t.index ["leader_id"], name: "index_main_point_of_contacts_on_leader_id", using: :btree
+  end
+
   create_table "tech_domain_redemptions", force: :cascade do |t|
     t.text     "name"
     t.text     "email"
@@ -124,4 +135,6 @@ ActiveRecord::Schema.define(version: 20170119233357) do
 
   add_foreign_key "check_ins", "clubs"
   add_foreign_key "check_ins", "leaders"
+  add_foreign_key "main_point_of_contacts", "clubs"
+  add_foreign_key "main_point_of_contacts", "leaders"
 end

--- a/spec/factories/main_point_of_contacts.rb
+++ b/spec/factories/main_point_of_contacts.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :main_point_of_contact do
+    leader nil
+    club nil
+  end
+end

--- a/spec/models/main_point_of_contact_spec.rb
+++ b/spec/models/main_point_of_contact_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe MainPointOfContact, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
This PR changes the CheckIn conversation so that it asks the leader if they are interested in being the 'main point of contact'.

Things I want to do a bit better:

- [x] Handle the transition from `start` to `determine_poc` better
- [x] Better articulate what being the 'main point of contact' means

I'd like some structural feedback on how I've actually implemented this from @zachlatta and @MaxWofford if at all possible though.
