### PR TITLE
Add question asking why a meeting didn't happen

### DIFF
--- a/app/models/hackbot/conversations/check_in.rb
+++ b/app/models/hackbot/conversations/check_in.rb
@@ -56,7 +56,7 @@ module Hackbot
       # rubocop:enable Metrics/MethodLength
 
       def wait_for_no_meeting_reason(event)
-        data['no_meeting_reason'] = event[:text]
+        data['notes'] = event[:text]
 
         msg_channel 'Gotcha. Hope you have a hack-tastic weekend!'
       end

--- a/app/models/hackbot/conversations/check_in.rb
+++ b/app/models/hackbot/conversations/check_in.rb
@@ -41,9 +41,11 @@ module Hackbot
 
           :wait_for_day_of_week
         when /(no|nope|nah|negative)/i
-          msg_channel 'Gotcha! Hope you have a great weekend.'
+          msg_channel "That's a shame! Was there a particular reason the "\
+                      "meeting didn't happen? Is there anything the Hack "\
+                      'Club team can be helpful with?'
 
-          :finish
+          :wait_for_no_meeting_reason
         else
           msg_channel "I'm not very smart yet and had trouble understanding "\
                       'you :-/. Try saying something like "yes" or "no".'
@@ -52,6 +54,12 @@ module Hackbot
         end
       end
       # rubocop:enable Metrics/MethodLength
+
+      def wait_for_no_meeting_reason(event)
+        data['no_meeting_reason'] = event[:text]
+
+        msg_channel 'Gotcha. Hope you have a hack-tastic weekend!'
+      end
 
       # rubocop:disable Metrics/MethodLength
       def wait_for_day_of_week(event)

--- a/app/models/hackbot/conversations/check_in.rb
+++ b/app/models/hackbot/conversations/check_in.rb
@@ -56,7 +56,7 @@ module Hackbot
       # rubocop:enable Metrics/MethodLength
 
       def wait_for_no_meeting_reason(event)
-        data['notes'] = event[:text] unless event[:text] =~ /^(no|nope|nah)$/i
+        record_notes event
 
         msg_channel 'Gotcha. Hope you have a hack-tastic weekend!'
       end
@@ -135,7 +135,7 @@ module Hackbot
       # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength
 
       def wait_for_notes(event)
-        data['notes'] = event[:text] unless event[:text] =~ /^(no|nope|nah)$/i
+        record_notes event
 
         ::CheckIn.create!(
           club: club(event),
@@ -150,6 +150,10 @@ module Hackbot
       end
 
       private
+
+      def record_notes(event)
+        data['notes'] = event[:text] unless event[:text] =~ /^(no|nope|nah)$/i
+      end
 
       def first_check_in?
         CheckIn.where("data->>'channel' = ?", data['channel']).empty?

--- a/app/models/hackbot/conversations/check_in.rb
+++ b/app/models/hackbot/conversations/check_in.rb
@@ -152,7 +152,7 @@ module Hackbot
       private
 
       def should_record_notes?(event)
-        !event[:text] =~ /^(no|nope|nah)$/i
+        (event[:text] =~ /^(no|nope|nah)$/i).nil?
       end
 
       def record_notes(event)

--- a/app/models/hackbot/conversations/check_in.rb
+++ b/app/models/hackbot/conversations/check_in.rb
@@ -56,7 +56,7 @@ module Hackbot
       # rubocop:enable Metrics/MethodLength
 
       def wait_for_no_meeting_reason(event)
-        record_notes event
+        record_notes event if should_record_notes? event
 
         msg_channel 'Gotcha. Hope you have a hack-tastic weekend!'
       end
@@ -135,7 +135,7 @@ module Hackbot
       # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength
 
       def wait_for_notes(event)
-        record_notes event
+        record_notes event if should_record_notes? event
 
         ::CheckIn.create!(
           club: club(event),
@@ -151,8 +151,12 @@ module Hackbot
 
       private
 
+      def should_record_notes?(event)
+        !event[:text] =~ /^(no|nope|nah)$/i
+      end
+
       def record_notes(event)
-        data['notes'] = event[:text] unless event[:text] =~ /^(no|nope|nah)$/i
+        data['notes'] = event[:text]
       end
 
       def first_check_in?

--- a/app/models/hackbot/conversations/check_in.rb
+++ b/app/models/hackbot/conversations/check_in.rb
@@ -56,7 +56,7 @@ module Hackbot
       # rubocop:enable Metrics/MethodLength
 
       def wait_for_no_meeting_reason(event)
-        data['notes'] = event[:text]
+        data['notes'] = event[:text] unless event[:text] =~ /^(no|nope|nah)$/i
 
         msg_channel 'Gotcha. Hope you have a hack-tastic weekend!'
       end


### PR DESCRIPTION
In our last batch of Hackbot check ins, we had 74 clubs who did not meet. This is a problem, but the currently truly-horrifying-horror-movie-situation we have right now is that we have **no** idea why these clubs didn't meet.

This PR fixes that. When a leader states they haven't had a meeting this week, they'll be prompted for why this was.