### PR TITLE
Fix help triggering too often

### DIFF
--- a/app/models/hackbot/conversation.rb
+++ b/app/models/hackbot/conversation.rb
@@ -12,6 +12,11 @@ module Hackbot
       raise NotImplementedError
     end
 
+    def self.mentions_name?(event, team)
+      event[:text].include?(team[:bot_username]) ||
+        event[:text].include?("<@#{team[:bot_user_id]}>")
+    end
+
     def part_of_convo?(event)
       # Don't react to events that we cause
       event[:user] != team.bot_user_id

--- a/app/models/hackbot/conversations/help.rb
+++ b/app/models/hackbot/conversations/help.rb
@@ -11,7 +11,7 @@ module Hackbot
                   'learn some new tricks from you!'.freeze
 
       def self.should_start?(event, team)
-        event[:text] =~ /help/ && event[:user] != team.bot_user_id
+        event[:text].include?('help') && mentions_name?(event, team)
       end
 
       def start(_event)

--- a/app/models/hackbot/conversations/mention.rb
+++ b/app/models/hackbot/conversations/mention.rb
@@ -2,9 +2,7 @@ module Hackbot
   module Conversations
     class Mention < Hackbot::Conversations::Channel
       def self.should_start?(event, team)
-        event[:type] == 'message' &&
-          (event[:text].include?(team[:bot_username]) ||
-           event[:text].include?("<@#{team[:bot_user_id]}>"))
+        event[:type] == 'message' || mentions_name?(event, team)
       end
 
       def start(_event)


### PR DESCRIPTION
This PR fixes the issue where people mention `help` in casual conversation, and hackbot subsequently decides it is it's queue to spam the channel with a quick bio. It's rather insensitive.

As part of this I've added a new class method, `mentions_name?` to `Hackbot::Conversation`, I've noticed that the mention code is starting to be repeated (and I imagine it will continue to in the future).