### PR TITLE
Add specific usernames option

### DIFF
--- a/app/jobs/leader_check_ins_job.rb
+++ b/app/jobs/leader_check_ins_job.rb
@@ -6,8 +6,10 @@ class LeaderCheckInsJob < ApplicationJob
   ACTIVE_STAGE_KEY = '5006'.freeze
   LEADER_PIPELINE_KEY = Rails.application.secrets.streak_leader_pipeline_key
 
-  def perform(*)
-    active_leader_usernames.each do |username|
+  def perform(usernames = [])
+    usernames = active_leader_usernames if usernames.empty?
+
+    usernames.each do |username|
       user = user_from_username(username)
       next if user.nil? # couldn't find the user
 


### PR DESCRIPTION
This PR adds the ability for us to explicitly specify which usernames to send leader check ins to.