### PR TITLE
Add notes to task handoff

### DIFF
--- a/app/models/hackbot/conversations/check_in.rb
+++ b/app/models/hackbot/conversations/check_in.rb
@@ -135,7 +135,7 @@ module Hackbot
       # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength
 
       def wait_for_notes(event)
-        record_notes event if should_record_notes? event
+        handle_notes event
 
         ::CheckIn.create!(
           club: club(event),
@@ -150,6 +150,20 @@ module Hackbot
       end
 
       private
+
+      def handle_notes(event)
+        next unless should_record_notes? event
+
+        lead = leader(event)
+
+        record_notes event
+
+        StreakClient.create_in_box(
+          lead.streak_key,
+          event[:text],
+          Time.zone.now.next_week(:monday)
+        )
+      end
 
       def should_record_notes?(event)
         (event[:text] =~ /^(no|nope|nah)$/i).nil?

--- a/lib/streak_client.rb
+++ b/lib/streak_client.rb
@@ -17,6 +17,16 @@ module StreakClient
       @api_base + url
     end
 
+    # Streak, usually, expects to be fed JSON on it's REST API. However, there
+    # is an inconsistency on the POST /v1/{box}/tasks endpoint.  Instead of
+    # this endpoint expecting JSON, it expects that it's parameters are encoded
+    # as part of the URL. The default value for `encoding` is :auto, which will
+    # choose what the encoding should be depending on the `method` parameter
+    # (POST = :json_encoding.  PUT, GET = :url_encoding). Specifying
+    # `encoding=:url_encoding` will force the parameters to be encoded in the
+    # URL, and `encoding:json` will force the URLs to be encoded in the body as
+    # JSON.
+    #
     # rubocop:disable Metrics/MethodLength
     def request(method, path, params = {}, headers = {}, encoding = :auto)
       payload = nil

--- a/lib/streak_client/task.rb
+++ b/lib/streak_client/task.rb
@@ -1,0 +1,16 @@
+module StreakClient
+  module Task
+    def self.create_in_box(box_key, text, due)
+      StreakClient.request(
+        :post,
+        "/v2/boxes/#{box_key}/tasks",
+        {
+          text: text,
+          due_date: (due.to_f * 1000).to_i
+        },
+        {},
+        :url_encoding
+      )
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a feature to `Hackbot::Conversations::CheckIn` which allows us to track the progress of all the requests which our leaders make during their respective check ins.