### PR TITLE
Add postgresql-client to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM ruby:2.3.1
 MAINTAINER Zach Latta <zach@hackclub.com>
 
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev \
+  postgresql-client
 
 RUN mkdir /usr/src/app
 WORKDIR /usr/src/app


### PR DESCRIPTION
This PR closes #73.

This allows you to connect to the development database using the Postgres CLI client and use the Rails command `rails dbconsole` to launch the Postgres REPL with the local databases.