### PR TITLE
Hackbot follow-ups

### DIFF
--- a/app/jobs/follow_up_if_needed_job.rb
+++ b/app/jobs/follow_up_if_needed_job.rb
@@ -1,35 +1,24 @@
 class FollowUpIfNeededJob < ApplicationJob
   HACK_CLUB_TEAM_ID = 'T0266FRGM'.freeze
 
-  def perform(conversation_id,
-              last_state_name,
-              last_message_timestamp,
-              follow_up_interval,
-              messages_to_follow_up_with)
-    conversation = Hackbot::Conversation.find conversation_id
+  def perform(conversation_id, last_state_name, last_message_timestamp,
+              follow_up_interval, messages_to_follow_up_with)
+    convo = Hackbot::Conversation.find conversation_id
 
-    return if conversation.nil?
+    return if convo.nil?
 
-    return if last_state_name != conversation.state
+    return if last_state_name != convo.state
 
-    return if last_message_timestamp != conversation.data['last_message_ts']
+    return if last_message_timestamp != convo.data['last_message_ts']
 
     return if messages_to_follow_up_with.empty?
 
-    send_follow_up(
-      messages_to_follow_up_with.shift,
-      conversation.data['channel']
-    )
+    send_follow_up(messages_to_follow_up_with.shift, convo.data['channel'])
 
     FollowUpIfNeededJob
       .set(wait: follow_up_interval)
-      .perform_later(
-        conversation_id,
-        last_state_name,
-        last_message_timestamp,
-        follow_up_interval,
-        messages_to_follow_up_with
-      )
+      .perform_later(conversation_id, last_state_name, last_message_timestamp,
+                     follow_up_interval, messages_to_follow_up_with)
   end
 
   private

--- a/app/jobs/follow_up_if_needed_job.rb
+++ b/app/jobs/follow_up_if_needed_job.rb
@@ -1,0 +1,52 @@
+class FollowUpIfNeededJob < ApplicationJob
+  HACK_CLUB_TEAM_ID = 'T0266FRGM'.freeze
+
+  def perform(conversation_id,
+              last_state_name,
+              last_message_timestamp,
+              follow_up_interval,
+              messages_to_follow_up_with)
+    conversation = Hackbot::Conversation.find conversation_id
+
+    return if conversation.nil?
+
+    return if last_state_name != conversation.state
+
+    return if last_message_timestamp != conversation.data['last_message_ts']
+
+    return if messages_to_follow_up_with.empty?
+
+    send_follow_up(
+      messages_to_follow_up_with.shift,
+      conversation.data['channel']
+    )
+
+    FollowUpIfNeededJob
+      .set(wait: follow_up_interval)
+      .perform_later(
+        conversation_id,
+        last_state_name,
+        last_message_timestamp,
+        follow_up_interval,
+        messages_to_follow_up_with
+      )
+  end
+
+  private
+
+  def send_follow_up(msg, channel)
+    SlackClient.rpc('chat.postMessage',
+                    access_token,
+                    channel: channel,
+                    text: msg,
+                    as_user: true)
+  end
+
+  def access_token
+    slack_team.bot_access_token
+  end
+
+  def slack_team
+    Hackbot::Team.find_by(team_id: HACK_CLUB_TEAM_ID)
+  end
+end

--- a/app/jobs/leader_check_ins_job.rb
+++ b/app/jobs/leader_check_ins_job.rb
@@ -57,10 +57,9 @@ class LeaderCheckInsJob < ApplicationJob
   end
 
   def active_leader_slack_ids
-    #active_leaders
-    #  .map(&:slack_id)
-    #  .reject { |u| u.nil? || u.empty? }
-    [user_from_username('harrison')[:id]]
+    active_leaders
+      .map(&:slack_id)
+      .reject { |u| u.nil? || u.empty? }
   end
 
   def active_leaders

--- a/app/jobs/leader_check_ins_job.rb
+++ b/app/jobs/leader_check_ins_job.rb
@@ -14,7 +14,7 @@ class LeaderCheckInsJob < ApplicationJob
       im = open_im(user_id)
       event = construct_fake_event(user_id, im[:channel][:id])
 
-      convo = Hackbot::Conversations::CheckIn.new(team: slack_team)
+      convo = Hackbot::Conversations::CheckIn.create(team: slack_team)
       convo.handle(event)
       convo.save!
     end
@@ -32,7 +32,8 @@ class LeaderCheckInsJob < ApplicationJob
       team_id: slack_team.team_id,
       user: user_id,
       type: 'message',
-      channel: channel_id
+      channel: channel_id,
+      ts: 'fake.timestamp'
     }
   end
 
@@ -56,9 +57,10 @@ class LeaderCheckInsJob < ApplicationJob
   end
 
   def active_leader_slack_ids
-    active_leaders
-      .map(&:slack_id)
-      .reject { |u| u.nil? || u.empty? }
+    #active_leaders
+    #  .map(&:slack_id)
+    #  .reject { |u| u.nil? || u.empty? }
+    [user_from_username('harrison')[:id]]
   end
 
   def active_leaders

--- a/app/models/hackbot/conversations/check_in.rb
+++ b/app/models/hackbot/conversations/check_in.rb
@@ -149,7 +149,7 @@ module Hackbot
       private
 
       def default_follow_up next_state
-        interval = 10.seconds
+        interval = 24.hours
 
         messages = [
           'Hey! Just wanted to follow-up on this :)',

--- a/app/models/hackbot/conversations/check_in.rb
+++ b/app/models/hackbot/conversations/check_in.rb
@@ -5,7 +5,7 @@
 module Hackbot
   module Conversations
     # rubocop:disable Metrics/ClassLength
-    class CheckIn < Hackbot::Conversations::Followup
+    class CheckIn < Hackbot::Conversations::FollowUp
       def self.should_start?(event, _team)
         event[:text] == 'check in'
       end
@@ -151,12 +151,12 @@ module Hackbot
         interval = 24.hours
 
         messages = [
-          'Hey! Just wanted to follow-up on this :)',
-          'Ping.',
-          'Yo – this is my last ping for you'
+          copy('follow_ups.first'),
+          copy('follow_ups.second'),
+          copy('follow_ups.third')
         ]
 
-        follow_up messages, next_state, interval
+        follow_up(messages, next_state, interval)
       end
 
       def should_record_notes?(event)

--- a/app/models/hackbot/conversations/check_in.rb
+++ b/app/models/hackbot/conversations/check_in.rb
@@ -11,8 +11,7 @@ module Hackbot
       end
 
       def start(event)
-        leader_info = leader(event)
-        first_name = leader_info.name.split(' ').first
+        first_name = leader(event).name.split(' ').first
 
         if first_check_in?
           msg_channel copy('first_greeting', first_name: first_name)
@@ -53,7 +52,7 @@ module Hackbot
         msg_channel copy('no_meeting_reason')
       end
 
-      # rubocop:disable Metrics/MethodLength
+      # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       def wait_for_day_of_week(event)
         meeting_date = Chronic.parse(event[:text], context: :past)
 
@@ -78,7 +77,7 @@ module Hackbot
         default_follow_up 'wait_for_attendance'
         :wait_for_attendance
       end
-      # rubocop:enable Metrics/MethodLength
+      # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
       # rubocop:disable Metrics/CyclomaticComplexity,
       # rubocop:disable Metrics/MethodLength
@@ -148,7 +147,7 @@ module Hackbot
 
       private
 
-      def default_follow_up next_state
+      def default_follow_up(next_state)
         interval = 24.hours
 
         messages = [

--- a/app/models/hackbot/conversations/follow_up.rb
+++ b/app/models/hackbot/conversations/follow_up.rb
@@ -1,6 +1,6 @@
 module Hackbot
   module Conversations
-    class Followup < Hackbot::Conversations::Channel
+    class FollowUp < Hackbot::Conversations::Channel
       def handle(event)
         data['last_message_ts'] = event[:ts]
 

--- a/app/models/hackbot/conversations/followup.rb
+++ b/app/models/hackbot/conversations/followup.rb
@@ -7,7 +7,7 @@ module Hackbot
         super
       end
 
-      def follow_up(messages, next_state, interval=10.seconds)
+      def follow_up(messages, next_state, interval = 10.seconds)
         FollowUpIfNeededJob
           .set(wait: interval)
           .perform_later(
@@ -21,4 +21,3 @@ module Hackbot
     end
   end
 end
-

--- a/app/models/hackbot/conversations/followup.rb
+++ b/app/models/hackbot/conversations/followup.rb
@@ -1,0 +1,24 @@
+module Hackbot
+  module Conversations
+    class Followup < Hackbot::Conversations::Channel
+      def handle(event)
+        data['last_message_ts'] = event[:ts]
+
+        super
+      end
+
+      def follow_up(messages, next_state, interval=10.seconds)
+        FollowUpIfNeededJob
+          .set(wait: interval)
+          .perform_later(
+            id,
+            next_state,
+            data['last_message_ts'],
+            interval.to_i,
+            messages
+          )
+      end
+    end
+  end
+end
+

--- a/lib/data/copy/check_in.yml
+++ b/lib/data/copy/check_in.yml
@@ -34,3 +34,8 @@ attendance:
 notes:
     no_notes: Okay. Hope you have a hack-tastic weekend!
     had_notes: Sweet, I'll let them know! Hope you have a hactastic weekend!
+
+follow_ups:
+    first: "Hey! Just wanted to follow-up on this. :wink:"
+    second: "Ping. :wave:"
+    third: "Just a heads up – this is the last ping I'll send. :airplane_departure:"


### PR DESCRIPTION
Closes #87

This PR adds automated follow-ups to Hackbot, in the form of a delayed job.

In order to test, you probably want to change [this line](https://github.com/hackclub/api/compare/hackbot-follow-ups?expand=1#diff-10e8a2297a6c1b210e2f9f004785731cR171) to be a more test-reasonable number. I usually use `10.seconds`.

Cases that need to be tested:

- Not responding to Hackbot will trigger a message
- Responding to Hackbot after it has pinged you will stop it from continuing to ping you.
- Hackbot correctly follows up after the correct messages (ie. if the conversation is finished, there is no need to follow-up)
- If the conversation is killed before it is finished, Hackbot will not continue following up.
- Hackbot is sending the correct pings in the correct order.
- Hackbot stops pinging after there are no messages left.