### PR TITLE
Fix POC system

### DIFF
--- a/app/jobs/leader_check_ins_job.rb
+++ b/app/jobs/leader_check_ins_job.rb
@@ -25,7 +25,7 @@ class LeaderCheckInsJob < ApplicationJob
 
   def start_check_in(event)
     convo = Hackbot::Conversations::CheckIn.create(team: slack_team)
-    convo.handle(event)
+    convo.handle event
     convo.save!
   end
 


### PR DESCRIPTION
We kind of left the point of contact system in a weird place last week, everything was implemented into the database and Streak but no changes were made to accomodate those in `LeaderCheckInsJob`.

This is those changes.

**Note: In order to properly test the code you will have to move a test leader into the `ACTIVE` stage for a short period of time.**

**Functionality**
- Streak keys can be provided through `LeaderCheckInsJob.perform_now keys` parameter.
- Only leaders in the active stage will be pinged during a check in.

**Things to test!**

- Leaders will be correctly classified as active or not active based off of their position in the Streak Club Leaders pipeline
- The job only pings leaders which are active
- If a list of Streak keys is provided as a parameter, they will be used instead of the leaders in the active leader pipeline
- The job will ignore all invalid Streak keys
- Only starts check ins with clubs which have POCs set

Starting assumptions:

- One leader with a valid slack username
- One leader without a slack username
- One leader with not slack username