### PR TITLE
Fix copy service bug

### DIFF
--- a/app/services/copy_service.rb
+++ b/app/services/copy_service.rb
@@ -5,8 +5,14 @@ class CopyService
   end
 
   def get_copy(key)
+    erb = ERB.new get_erb(key)
+
+    erb.result @context
+  end
+
+  def get_erb(key)
     sections = key.split '.'
-    copy = get_conversation(@conversation_name)
+    copy = get_conversation_yaml(@conversation_name)
 
     sections.each { |s| copy = copy[s] }
 
@@ -16,11 +22,10 @@ class CopyService
 
   private
 
-  def get_conversation(name)
+  def get_conversation_yaml(name)
     path = File.join(copy_route, "#{name}.yml")
-    copy = ERB.new(File.read(path)).result @context
 
-    YAML.load(copy)
+    YAML.load File.read(path)
   end
 
   def copy_route


### PR DESCRIPTION
My explanation from Slack with @MaxWofford.

> figured out the problem
> 
> [1:56]  
> some of our clubs have `\r` appended to the back of their names
> 
> [1:56]  
> when this is rendered
> 
> [1:56]  
> it takes the valid [yaml]
> 
> [1:57]  
>  ```
> key: <%= info[:value] %> by bob
> key2: potato
> ```
> (edited)
> 
> [1:57]  
> and turns it into
> 
> [1:57]  
> (with `value=hello\r`)
> 
> [1:58]  
>  ```key: hello
>  by bob
> key2: potato
> ```
> (edited)
> [which is not valid yaml]

TLDR: Some of our club names in the database have extraneous newlines post-pended to them. This was fucking with YAML, to fix this I've changed the order in which we use ERB and YAML. (Used to be `ERB to YAML`, now is `YAML to ERB`)