### PR TITLE
Add Streak tasks which are generated from notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ SLACK_TEAM_ID
 
 # Secret code required when redeeming .tech domains
 TECH_DOMAIN_REDEMPTION_SECRET_CODE
+
+# The email of who to assign Streak tasks to
+DEFAULT_STREAK_TASK_ASSIGNEE
 ```
 
 ## Other Setup

--- a/circle.yml
+++ b/circle.yml
@@ -15,6 +15,7 @@ machine:
     SLACK_TEAM_ID: fake_slack_team_id
     TECH_DOMAIN_REDEMPTION_SECRET_CODE: fake_secret_code
     GIPHY_API_KEY: fake_giphy_api_key
+    DEFAULT_STREAK_TASK_ASSIGNEE: email@email.email
 
 test:
   override:

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -32,6 +32,7 @@ common: &common
   tech_domain_redemption_secret_code: <%= ENV.fetch("TECH_DOMAIN_REDEMPTION_SECRET_CODE") %>
 
   giphy_api_key: <%= ENV.fetch("GIPHY_API_KEY") %>
+  default_streak_task_assignee: <%= ENV.fetch("DEFAULT_STREAK_TASK_ASSIGNEE") %>
 
 development:
   <<: *common


### PR DESCRIPTION
This PR closes #88.

Things to test:

- Tasks get assigned to the right person
- Tasks are generated when there are notes outputted from a conversation. (1. if there wasn't a meeting. 2. if there was a meeting)

I've already configured our production environment to put @kyleemile as the default assignee.