### PR TITLE
Add flag to not use timezones and send check ins immediately

### DIFF
--- a/app/jobs/schedule_leader_check_ins_job.rb
+++ b/app/jobs/schedule_leader_check_ins_job.rb
@@ -6,12 +6,12 @@ class ScheduleLeaderCheckInsJob < ApplicationJob
   LEADER_ACTIVE_STAGE_KEY = '5006'.freeze
   LEADER_PIPELINE_KEY = Rails.application.secrets.streak_leader_pipeline_key
 
-  def perform(real_run = false)
+  def perform(real_run = false, timezones = true)
     dry_run_notification unless real_run
     pocs.each do |poc|
       trigger_time = time_offset(poc[:latitude], poc[:longitude])
 
-      schedule_check_in(real_run, trigger_time, streak_key)
+      schedule_check_in(real_run, timezones, trigger_time, poc.streak_key)
     end
   end
 
@@ -23,14 +23,20 @@ class ScheduleLeaderCheckInsJob < ApplicationJob
     sleep 5.seconds
   end
 
-  def schedule_check_in(real_run, trigger_time, streak_key)
+  def schedule_check_in(real_run, timezones, trigger_time, streak_key)
     msg = (real_run ? '' : '(Dry run) ')
     msg << "Scheduling check-in at #{trigger_time} for #{streak_key}"
     Rails.logger.info msg
 
     return unless real_run
 
-    LeaderCheckInJob.set(wait_until: trigger_time).perform_later(streak_key)
+    job = if timezones
+            LeaderCheckInJob.set(wait_until: trigger_time)
+          else
+            LeaderCheckInJob
+          end
+
+    job.perform_later(streak_key)
   end
 
   def time_offset(lat, lng, day = 'friday', local_time = 17.hours)


### PR DESCRIPTION
This PR adds a flag to schedule all check ins to run immediately, instead of trying to schedule them.

It's useful in cases of emergencies or when we don't know if the Google Maps API key we're using has TimeZones enabled.