### PR TITLE
Fix errors from conversations responding to non-messages

### DIFF
--- a/app/models/hackbot/conversations/gifs.rb
+++ b/app/models/hackbot/conversations/gifs.rb
@@ -2,7 +2,8 @@ module Hackbot
   module Conversations
     class Gifs < Hackbot::Conversations::Channel
       def self.should_start?(event, team)
-        event[:text].downcase.include?('gif') && mentions_name?(event, team)
+        event[:type].eql?('message') && event[:text].downcase.include?('gif') &&
+          mentions_name?(event, team)
       end
 
       def start(event)

--- a/app/models/hackbot/conversations/gifs.rb
+++ b/app/models/hackbot/conversations/gifs.rb
@@ -2,7 +2,8 @@ module Hackbot
   module Conversations
     class Gifs < Hackbot::Conversations::Channel
       def self.should_start?(event, team)
-        event[:type].eql?('message') && event[:text].downcase.include?('gif') &&
+        event[:type].eql?('message') &&
+          event[:text].downcase.include?('gif') &&
           mentions_name?(event, team)
       end
 

--- a/app/models/hackbot/conversations/help.rb
+++ b/app/models/hackbot/conversations/help.rb
@@ -2,7 +2,8 @@ module Hackbot
   module Conversations
     class Help < Hackbot::Conversations::Channel
       def self.should_start?(event, team)
-        event[:text].downcase.include?('help') && mentions_name?(event, team)
+        event[:type].eql?('message') &&
+          event[:text].downcase.include?('help') && mentions_name?(event, team)
       end
 
       def start(_event)

--- a/app/models/hackbot/conversations/help.rb
+++ b/app/models/hackbot/conversations/help.rb
@@ -3,7 +3,8 @@ module Hackbot
     class Help < Hackbot::Conversations::Channel
       def self.should_start?(event, team)
         event[:type].eql?('message') &&
-          event[:text].downcase.include?('help') && mentions_name?(event, team)
+          event[:text].downcase.include?('help') &&
+          mentions_name?(event, team)
       end
 
       def start(_event)


### PR DESCRIPTION
This PR fixes our various conversations [throwing errors](https://sentry.io/hack-club/api/issues/230714483/) when they have to process events that aren't of type `message`.