### PR TITLE
Fix typo preventing submission of .TECH domain requests

### DIFF
--- a/lib/dot_tech_client.rb
+++ b/lib/dot_tech_client.rb
@@ -28,7 +28,7 @@ module DotTechClient
         iphorm_6_1: person_name,
         iphorm_6_2: person_email,
         iphorm_6_3: COMPANY_NAME,
-        iphone_6_4: requested_domain
+        iphorm_6_4: requested_domain
       )
 
       request(:post, '/startups/', params)


### PR DESCRIPTION
This PR fixes a typo that was preventing submission of .TECH domain requests (thanks to @mj66, @lachlanjc, and the many others that caught this).

Once this is merged, we'll have to retroactively submit existing requests. I can take care of that.