### PR TITLE
Add new no meeting conversation flow

### DIFF
--- a/app/models/hackbot/interactions/check_in.rb
+++ b/app/models/hackbot/interactions/check_in.rb
@@ -51,13 +51,44 @@ module Hackbot
       # rubocop:enable Metrics/MethodLength
 
       def wait_for_no_meeting_reason
+        data['no_meeting_reason'] = msg
+
+        msg_channel copy('no_meeting_reason')
+
+        default_follow_up 'wait_for_meeting_in_the_future'
+        :wait_for_meeting_in_the_future
+      end
+
+      # rubocop:disable Metrics/MethodLength
+      def wait_for_meeting_in_the_future
+        case msg
+        when Hackbot::Utterances.yes
+          msg_channel copy('meeting_in_the_future.positive')
+
+          default_follow_up 'wait_for_help'
+          :wait_for_help
+        when Hackbot::Utterances.no
+          msg_channel copy('meeting_in_the_future.negative')
+          data['wants_to_be_dead'] = true
+
+          :finish
+        else
+          msg_channel copy('meeting_in_the_future.invalid')
+
+          default_follow_up 'wait_for_meeting_in_the_future'
+          :wait_for_meeting_in_the_future
+        end
+      end
+      # rubocop:enable Metrics/MethodLength
+
+      def wait_for_help
         if should_record_notes?
           notes = record_notes
           create_task leader, 'Follow-up on notes from a failed '\
             "meeting: #{notes}"
         end
 
-        msg_channel copy('no_meeting_reason')
+        msg_channel copy('help')
       end
 
       # rubocop:disable Metrics/MethodLength, Metrics/AbcSize

--- a/lib/data/copy/check_in.yml
+++ b/lib/data/copy/check_in.yml
@@ -9,10 +9,18 @@ greeting: Hey <%= info[:first_name] %>! Did you have a club meeting this week?
 
 meeting_confirmation:
     positive: Okay, sweet! On which day was it? (say something like "monday" or "today" – I'm not very clever)
-    negative: That's a shame! Was there a particular reason the meeting didn't happen? Is there anything the Hack Club team can be helpful with?
+    negative: That's a shame! Was there a particular reason the meeting didn't happen?
     invalid: I'm not very smart yet and had trouble understanding you :-/. Try saying something like 'yes' or 'no'.
 
-no_meeting_reason: Gotcha. Hope you have a hack-tastic weekend!
+no_meeting_reason: Gotcha. Are you planning on having a club meeting in the future?
+
+meeting_in_the_future:
+    positive: Awesome! Is there anything the Hack Club team can be helpful with in the meantime?
+    negative: That's a shame. I'll let the Hack Club team know.
+    invalid: I'm not very smart yet and had trouble understanding you :-/. Try saying something like 'yes' or 'no'
+
+help:
+    Got it! Have a hack-tastic weekend!
 
 day_of_week:
     unknown: Man, I'm not very smart yet and had trouble understanding you. Try saying something simpler, like "tuesday" or "thursday".
@@ -33,7 +41,7 @@ attendance:
 
 notes:
     no_notes: Okay. Hope you have a hack-tastic weekend!
-    had_notes: Sweet, I'll let them know! Hope you have a hactastic weekend!
+    had_notes: Sweet, I'll let them know! Hope you have a hack-tastic weekend!
 
 follow_ups:
     first: "Hey! Just wanted to follow-up on this. :wink:"


### PR DESCRIPTION
This PR adds a new conversation flow for check ins if the leader says they did not have a club meeting.

Here's the spec sheet I got from @kyleemile. I've changed the copy around a bit to make it better.

```
Hackbot: Hi, time for check-in's, did you have a meeting this last week? 
User: No

Hackbot: How unfortunate, why wasn't there a meeting?
User: [explanation]

Hackbot: Are you planning on having club meetings in the future?
User: [y/n]

    If NO: 
    Hackbot: Aww, that's sad to hear. I'll be sure to let the Hack Club Team know.

    IF YES: 
    Hackbot: Sweet, is there anything that the Hack Club team can be helpful with? 
    User: [answer]

    Hackbot: Got it. That's all for now. 
```

Tests:

- Correct copy is used in all the flow
- No meeting reason is recorded in the data object (key: `no_meeting_reason`)
- Conversation is marked with `wants_to_be_dead` in data object if the leader is not planning on having more meetings
- Streak Tasks are created if there is something which the Hack Club team can be helpful with