### PR TITLE
Fix stats command not handling invalid input correctly

### DIFF
--- a/app/models/hackbot/interactions/stats.rb
+++ b/app/models/hackbot/interactions/stats.rb
@@ -4,26 +4,34 @@ module Hackbot
       TRIGGER = /stats/
 
       def start
-        stats = statistics
-
-        if stats.nil?
-          msg_channel copy('invalid')
-
-          return :finish
+        if valid_stats?
+          msg_channel copy('stats', school_name: stats.club_name,
+                                    days_alive: stats.days_alive,
+                                    total_meetings: stats.total_meetings_count,
+                                    avg_attendance: stats.average_attendance)
+        else
+          handle_invalid_stats
         end
-
-        msg_channel copy('stats', school_name: stats.club_name,
-                                  days_alive: stats.days_alive,
-                                  total_meetings: stats.total_meetings_count,
-                                  avg_attendance: stats.average_attendance)
       end
 
       private
 
-      def statistics
-        return nil unless leader
+      def valid_stats?
+        !(stats.leader.nil? || stats.check_ins.length <= 2)
+      end
 
-        ::StatsService.new(leader)
+      def handle_invalid_stats
+        selector = if stats.leader.nil?
+                     'leader'
+                   else
+                     'check_ins'
+                   end
+
+        msg_channel copy("invalid.#{selector}")
+      end
+
+      def stats
+        @stats ||= ::StatsService.new(leader)
       end
 
       def leader

--- a/app/services/stats_service.rb
+++ b/app/services/stats_service.rb
@@ -1,6 +1,8 @@
 class StatsService
   GRAPH_SAMPLES = 4
 
+  attr_accessor :check_ins, :leader
+
   def initialize(leader)
     @leader = leader
     @check_ins = ::CheckIn.where(leader: leader).order('meeting_date ASC')

--- a/lib/data/copy/stats.yml
+++ b/lib/data/copy/stats.yml
@@ -1,6 +1,6 @@
 invalid:
     leader: You don't seem to be a club leader! I can't get any stats for you :(
-    check_ins: You haven't had enough meetings for there to be any stats for you yet :(
+    check_ins: I can give you stats once you've had 3 meetings.
 
 stats: |
     These are stats for your club at <%= info[:school_name] %>!

--- a/lib/data/copy/stats.yml
+++ b/lib/data/copy/stats.yml
@@ -1,4 +1,6 @@
-invalid: You're not a club leader! I currently only know how to give stats to club leaders.
+invalid:
+    leader: You don't seem to be a club leader! I can't get any stats for you :(
+    check_ins: You haven't had enough meetings for there to be any stats for you yet :(
 
 stats: |
     These are stats for your club at <%= info[:school_name] %>!


### PR DESCRIPTION
Closes #145.

Tests:

- Slack user who is not a leader gets correct copy (and no errors)
- Leader who has not had 3 check ins gets correct copy (and no errors)
- A Leader who has had more than 3 check ins gets correct copy and a render of their stats