### PR TITLE
Start job worker with `docker-compose up`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,15 @@ services:
       - "3000:3000"
     depends_on:
       - db
+  worker:
+    build: .
+    command: bundle exec rails jobs:work
+    volumes:
+      - .:/usr/src/app
+    volumes_from:
+      - bundle
+    depends_on:
+      - db
   bundle:
     # You may need to run `docker-compose build web` before this works.
     image: alpine


### PR DESCRIPTION
This PR starts `rails jobs:work` when running `docker-compose up`.