### PR TITLE
Add check ins back into the dispatcher

### DIFF
--- a/app/models/hackbot/dispatcher.rb
+++ b/app/models/hackbot/dispatcher.rb
@@ -1,6 +1,7 @@
 module Hackbot
   class Dispatcher
     INTERACTION_TYPES = [
+      Hackbot::Interactions::CheckIn,
       Hackbot::Interactions::DiceRoll,
       Hackbot::Interactions::Gifs,
       Hackbot::Interactions::Help,

--- a/app/models/hackbot/interactions/check_in.rb
+++ b/app/models/hackbot/interactions/check_in.rb
@@ -10,6 +10,10 @@ module Hackbot
 
       TASK_ASSIGNEE = Rails.application.secrets.default_streak_task_assignee
 
+      def should_start?
+        false
+      end
+
       def start
         first_name = leader.name.split(' ').first
         deadline = formatted_deadline leader


### PR DESCRIPTION
Currently if we run check ins, Hackbot will not respond to any messages which should be part of that conversation. This is bad.