### PR TITLE
Refactor Hackbot copy system

### DIFF
--- a/app/models/hackbot/interaction.rb
+++ b/app/models/hackbot/interaction.rb
@@ -84,6 +84,8 @@ module Hackbot
     end
 
     def copy(key, hash = {}, source = default_copy_source)
+      hash = hash.merge default_copy_hash
+
       cs = ::CopyService.new(source, hash)
 
       cs.get_copy key
@@ -116,6 +118,13 @@ module Hackbot
 
     def default_copy_source
       self.class.name.demodulize.underscore
+    end
+
+    def default_copy_hash
+      {
+        team: team,
+        event: event
+      }
     end
   end
 end

--- a/app/models/hackbot/team.rb
+++ b/app/models/hackbot/team.rb
@@ -8,5 +8,9 @@ module Hackbot
     has_many :interactions,
              foreign_key: 'hackbot_team_id',
              class_name: ::Hackbot::Interaction
+
+    def bot_mention
+      "<@#{bot_user_id}>"
+    end
   end
 end

--- a/app/services/copy_service.rb
+++ b/app/services/copy_service.rb
@@ -34,7 +34,9 @@ class CopyService
 
   def hash_to_binding(hash)
     b = binding
-    b.local_variable_set('info', hash)
+
+    hash.each { |k, v| b.local_variable_set(k, v) }
+
     b
   end
 end

--- a/lib/data/copy/check_in.yml
+++ b/lib/data/copy/check_in.yml
@@ -1,11 +1,11 @@
 first_greeting: |
-    Hey <%= info[:first_name] %>! I'm Hackbot, Hack Club's friendly robot helper.
+    Hey <%= first_name %>! I'm Hackbot, Hack Club's friendly robot helper.
 
     I'll be reaching out to you every week, typically on Fridays, to check in and see how your club's doing. I'll be in the loop every step of the way :slightly_smiling_face:
 
     To start, did you have a club meeting this week?
 
-greeting: Hey <%= info[:first_name] %>! Let's get started — please be sure to complete this check-in by <%= info[:deadline] %>. Did your club meet this week?
+greeting: Hey <%= first_name %>! Let's get started — please be sure to complete this check-in by <%= deadline %>. Did your club meet this week?
 
 meeting_confirmation:
     positive: Okay, sweet! On which day was it? (say something like "monday" or "today" – I'm not very clever)
@@ -29,15 +29,15 @@ day_of_week:
 
 judgement:
     ok: Nice!
-    good: <%= info[:count] %> is a number to be proud of!
-    great: Damn, <%= info[:count] %> is a huge number of people!
-    awesome: I have no words. <%= info[:count] %> people is incredible!
+    good: <%= count %> is a number to be proud of!
+    great: Damn, <%= count %> is a huge number of people!
+    awesome: I have no words. <%= count %> people is incredible!
     impossible: I'm speechless. That's incredible.
 
 attendance:
     invalid: I didn't quite understand that. Can you try giving a single number?
     not_realistic: I'm going to need a positive number, silly. How many people came to the last meeting?
-    valid: <%= info[:judgement] %> Is there anything the Hack Club team can be helpful with? I'll send them anything you send my way (just make sure to include everything in a single message). If not, please respond with "no".
+    valid: <%= judgement %> Is there anything the Hack Club team can be helpful with? I'll send them anything you send my way (just make sure to include everything in a single message). If not, please respond with "no".
 
 notes:
     no_notes: Okay. Hope you have a hack-tastic weekend!

--- a/lib/data/copy/concerns/mirrorable.yml
+++ b/lib/data/copy/concerns/mirrorable.yml
@@ -1,18 +1,18 @@
 mirror_msg:
-  fallback: "<%= info[:slack_mention] %>: <%= info[:text] %>"
+  fallback: "<%= slack_mention %>: <%= text %>"
 mirror_attachments:
-  fallback: <%= info[:slack_mention] %> sent attachments
+  fallback: <%= slack_mention %> sent attachments
 mirror_file:
   text: |
-    Uploaded `<%= info[:filename] %>`.
+    Uploaded `<%= filename %>`.
 
     _Mirroring does not currently support showing uploaded files inline._
-  fallback: <%= info[:slack_mention] %> uploaded <%= info[:filename] %>
+  fallback: <%= slack_mention %> uploaded <%= filename %>
 template:
-  footer: <%= info[:source] %>, running <%= info[:interaction] %>, id <%= info[:id] %>
+  footer: <%= source %>, running <%= interaction %>, id <%= id %>
   source:
-    public_channel: "#<%= info[:channel_name] %>"
-    private_channel: "#<%= info[:channel_name] %> (private)"
-    mpim: Group chat w/ <%= info[:slack_mentions].to_sentence %>
-    dm: PM w/ <%= info[:slack_mention] %>
+    public_channel: "#<%= channel_name %>"
+    private_channel: "#<%= channel_name %> (private)"
+    mpim: Group chat w/ <%= slack_mentions.to_sentence %>
+    dm: PM w/ <%= slack_mention %>
     unknown: Unknown source

--- a/lib/data/copy/dice_roll.yml
+++ b/lib/data/copy/dice_roll.yml
@@ -1,7 +1,7 @@
-roll_1: Rolling a dice with <%= info[:side_count] %> sides...
+roll_1: Rolling a dice with <%= side_count %> sides...
 roll_2: ..
 roll_3: .
-roll_4: It came up <%= info[:result] %>!
+roll_4: It came up <%= result %>!
 errors:
   bad_side_count:
     You must give me a whole number for the side count! Try 42 instead.

--- a/lib/data/copy/help.yml
+++ b/lib/data/copy/help.yml
@@ -3,8 +3,8 @@ help: |
 
     Here are the commands I know:
 
-    <% info[:commands].each do |c| %>
+    <% commands.each do |c| %>
     `<%= c[:usage] %>` - <%= c[:desc] %>
     <% end %>
 
-    To use one of them, go ahead and say `<%= info[:bot_mention] %>` and then the command you want to run, like `<%= info[:bot_mention] %> <%= info[:commands].sample[:usage] %>`.
+    To use one of them, go ahead and say `<%= bot_mention %>` and then the command you want to run, like `<%= bot_mention %> <%= commands.sample[:usage] %>`.

--- a/lib/data/copy/set_poc.yml
+++ b/lib/data/copy/set_poc.yml
@@ -1,12 +1,12 @@
 start:
     invalid: I can't find that leader :-?
-    no_clubs: <%= info[:leader_name] %> is not associated with any clubs.
+    no_clubs: <%= leader_name %> is not associated with any clubs.
     many_clubs:
-        intro: <%= info[:leader_name] %> is associated with the following clubs
-        each: <%= info[:i] %>. <%= info[:club_name] %> <%= info[:club_name] %>
+        intro: <%= leader_name %> is associated with the following clubs
+        each: <%= i %>. <%= club_name %> <%= club_name %>
         outro: Please pick one and then send the number next to it.
 clubs_num:
-    invalid: Please choose a number between 1 and <%= info[:num_of_clubs] %>
+    invalid: Please choose a number between 1 and <%= num_of_clubs %>
 set:
-    success: <%= info[:leader_name] %> has been associated with <%= info[:club_name] %>
-    failure: Unable to associate <%= info[:leader_name] %> with <%= info[:club_name] %>
+    success: <%= leader_name %> has been associated with <%= club_name %>
+    failure: Unable to associate <%= leader_name %> with <%= club_name %>

--- a/lib/data/copy/stats.yml
+++ b/lib/data/copy/stats.yml
@@ -3,6 +3,6 @@ invalid:
     check_ins: I can give you stats once you've had 3 meetings.
 
 stats: |
-    These are stats for your club at <%= info[:school_name] %>!
+    These are stats for your club at <%= school_name %>!
 
-    In the <%= info[:days_alive] %> days you've been checking in with me, you've had <%= info[:total_meetings] %> meetings. Across all of your recorded club meetings, on average you have <%= info[:avg_attendance] %> attend your meetings.
+    In the <%= days_alive %> days you've been checking in with me, you've had <%= total_meetings %> meetings. Across all of your recorded club meetings, on average you have <%= avg_attendance %> attend your meetings.

--- a/lib/data/copy/welcome.yml
+++ b/lib/data/copy/welcome.yml
@@ -1,7 +1,7 @@
 welcome: |
-    Hey <%= info[:name] %>! Noticed you just filled out the intake form – welcome to Hack Club :hackclub:! My name is Hackbot, I'm our Slack's friendly robotic helper.
+    Hey <%= name %>! Noticed you just filled out the intake form – welcome to Hack Club :hackclub:! My name is <%= team.bot_username.titlecase %>, I'm our Slack's friendly robotic helper.
 
-    I can respond to specific commands you give me. For example, if you type `hackbot gif pugs`, I'll send you a gif of some adorable dogs. If you want a list of all the things I know how to do, just type `hackbot help`.
+    I can respond to specific commands you give me. For example, if you type `<%= team.bot_mention %> gif pugs`, I'll send you a gif of some adorable dogs. If you want a list of all the things I know how to do, just type `<%= team.bot_mention %> help`.
 
     I'm pretty basic right now, but I learn new things every week. In fact, if you have any ideas :bulb: for new features talk to <@U0C7BTKLG> or <@U0C7B14Q3>!
 


### PR DESCRIPTION
TLDR:

Using `{team: team, event: event, first_name: 'Harrison'}`

```yml
# message.yml

message: Helllo! I am <@<%= info[:team].bot_user_id %>. This events timestamp is <%= info[:event] %>. The custom parameter you passed in is <%= info[:first_name] %>.
```

Using `{first_name: 'Harrison'}`. (`team` and `event` are passed in at the `Hackbot::Interaction` level)

```yml
# message.yml

message: Hello! I am <%= team.bot_mention %>. This events timestamp is <%= event[:ts] %>. The custom parameter you passed in is <%= first_name %>.
```

This PR refactors Hackbot's copy system to be a bit nicer to play with.

- We now have some nice default values in available in the copy scope. You're able to access `event` and `team` without passing them in explicitly.
- Instead of accessing values through a hash, you access them directly. This means that if a value does not exist an error will be thrown. Be aware.

I've gone through and tried out all of the conversations to make sure they work, and I'm reasonably positive they do. However, I'd appreciate it if someone could just sanity check that for me 😆 

![https://media.giphy.com/media/iFkHQLzYA09Zm/giphy.gif](https://media.giphy.com/media/iFkHQLzYA09Zm/giphy.gif)