### PR TITLE
Create Procfile w/ three workers

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,4 @@
+web: bin/rails server -p $PORT -e $RAILS_ENV
+worker.1: bundle exec rake jobs:work
+worker.2: bundle exec rake jobs:work
+worker.3: bundle exec rake jobs:work


### PR DESCRIPTION
This change introduces a Procfile, which sets up 3 Heroku workers -- having the
three workers defined in the Procfile instead of through Heroku's config allows
us to use multiple hobby dynos for multiple workers, keeping costs down.