### PR TITLE
Add a limit on meeting sizes

### DIFF
--- a/app/models/hackbot/interactions/check_in.rb
+++ b/app/models/hackbot/interactions/check_in.rb
@@ -181,7 +181,7 @@ module Hackbot
         count = msg.to_i
 
         if count < 0
-          msg_channel copy('attendance.not_realistic.small')
+          msg_channel copy('attendance.not_realistic.negative')
 
           default_follow_up 'wait_for_attendance'
           return :wait_for_attendance
@@ -190,7 +190,7 @@ module Hackbot
         # Unless Hack Club starts expanding to other solar systems, this
         # number is completely implausible until at least 2025.
         if count > 8_000_000_000
-          msg_channel copy('attendance.not_realistic.large')
+          msg_channel copy('attendance.not_realistic.too_large')
 
           default_follow_up 'wait_for_attendance'
           return :wait_for_attendance

--- a/app/models/hackbot/interactions/check_in.rb
+++ b/app/models/hackbot/interactions/check_in.rb
@@ -181,7 +181,16 @@ module Hackbot
         count = msg.to_i
 
         if count < 0
-          msg_channel copy('attendance.not_realistic')
+          msg_channel copy('attendance.not_realistic.small')
+
+          default_follow_up 'wait_for_attendance'
+          return :wait_for_attendance
+        end
+
+        # Unless Hack Club starts expanding to other solar systems, this
+        # number is completely implausible until at least 2025.
+        if count > 8_000_000_000
+          msg_channel copy('attendance.not_realistic.large')
 
           default_follow_up 'wait_for_attendance'
           return :wait_for_attendance
@@ -199,7 +208,7 @@ module Hackbot
                     when 40..100
                       copy('judgement.awesome', count: count)
                     else
-                      copy('judgement.impossible')
+                      copy('judgement.amazing')
                     end
 
         msg_channel(

--- a/lib/data/copy/check_in.yml
+++ b/lib/data/copy/check_in.yml
@@ -37,11 +37,13 @@ judgement:
     good: <%= count %> is a number to be proud of!
     great: Damn, <%= count %> is a huge number of people!
     awesome: I have no words. <%= count %> people is incredible!
-    impossible: I'm speechless. That's incredible.
+    amazing: I'm speechless. That's incredible.
 
 attendance:
     invalid: I didn't quite understand that. Can you try giving a single number?
-    not_realistic: I'm going to need a positive number, silly. How many people came to the last meeting?
+    not_realistic:
+        small: I'm going to need a positive number, silly. How many people came to the last meeting?
+        large: There aren't even that many people on Earth yet! How many people actually came to your last meeting?
     valid: <%= judgement %> Is there anything the Hack Club team can be helpful with?
 
 notes_confirmation:

--- a/lib/data/copy/check_in.yml
+++ b/lib/data/copy/check_in.yml
@@ -42,8 +42,8 @@ judgement:
 attendance:
     invalid: I didn't quite understand that. Can you try giving a single number?
     not_realistic:
-        small: I'm going to need a positive number, silly. How many people came to the last meeting?
-        large: There aren't even that many people on Earth yet! How many people actually came to your last meeting?
+        negative: I'm going to need a positive number, silly. How many people came to the last meeting?
+        too_large: There aren't even that many people on Earth yet! How many people actually came to your last meeting?
     valid: <%= judgement %> Is there anything the Hack Club team can be helpful with?
 
 notes_confirmation:


### PR DESCRIPTION
This PR adds a hard limit on how big the attendance of a club meeting can be.

I chose the number 8 billion because we are not projected to even have a population that size (let everyone having access to the internet) until 2025.

If it's more appropriate, we could use `2147483647` which is the max size of a PostgreSQL integer? I just think that 8 billion is much more human.