### PR TITLE
(Unfinished WIP) Implement slash commands

### DIFF
--- a/app/controllers/v1/hackbot/webhooks_controller.rb
+++ b/app/controllers/v1/hackbot/webhooks_controller.rb
@@ -44,6 +44,14 @@ module V1
         end
       end
 
+      def slash_command
+        return if params[:ssl_check] == '1'
+
+        event = slash_command_payload_to_event(params)
+
+        handle_event(event, event[:team_id])
+      end
+
       private
 
       def handle_event(event, team_id)
@@ -77,6 +85,22 @@ module V1
                         a[:value] == action[:value]
           end
         end
+      end
+
+      # Note: this introduces a new subtype of message called "slash_command".
+      #
+      # This isn't part of Slack's API and only exists in the Hackbot realm for
+      # our convenience.
+      def slash_command_payload_to_event(payload)
+        {
+          type: 'message',
+          subtype: 'slash_command',
+          user: payload[:user_id],
+          text: payload[:text],
+          channel: payload[:channel_id],
+          team_id: payload[:team_id],
+          response_url: payload[:response_url]
+        }
       end
     end
   end

--- a/app/models/hackbot/interactions/command.rb
+++ b/app/models/hackbot/interactions/command.rb
@@ -15,9 +15,16 @@ module Hackbot
         #
         # http://stackoverflow.com/q/42779998/1001686
         trigger = self.class::TRIGGER
-        mention_regex = Hackbot::Utterances.name(team)
+        matcher = nil
 
-        msg =~ /^#{mention_regex} #{trigger}$/ && super
+        if event[:subtype] == 'slash_command'
+          matcher = /^#{trigger}$/
+        else
+          mention_regex = Hackbot::Utterances.name(team)
+          matcher = /^#{mention_regex} #{trigger}$/
+        end
+
+        msg =~ matcher && super
       end
 
       def captured
@@ -30,6 +37,36 @@ module Hackbot
 
       def description
         self.class::DESCRIPTION if self.class.const_defined? 'DESCRIPTION'
+      end
+
+      def reply(msg)
+        if event[:subtype] == 'slash_command'
+          opts = {}
+
+          if msg.is_a? String
+            opts[:text] = msg
+          else
+            opts = msg
+          end
+
+          if opts[:attachments]
+            opts[:attachments] = insert_attachment_defaults(opts[:attachments])
+          end
+
+          payload = { token: access_token, **opts }
+
+          RestClient::Request.execute(
+            method: :post,
+            url: event[:response_url],
+            payload: payload.to_json
+          )
+        else
+          msg_channel(msg)
+        end
+      end
+
+      def attach_reply(*attachments)
+        reply(attachments: attachments)
       end
     end
   end

--- a/app/models/hackbot/interactions/dice_roll.rb
+++ b/app/models/hackbot/interactions/dice_roll.rb
@@ -22,11 +22,11 @@ module Hackbot
           copy('roll_4', result: rand(1..side_count))
         ]
 
-        msgs.each { |m| msg_channel(m) && sleep(0.5) }
+        msgs.each { |m| reply(m) && sleep(0.5) }
       end
 
       def bad_side_count
-        msg_channel copy('errors.bad_side_count')
+        reply copy('errors.bad_side_count')
       end
 
       def integer?(str)

--- a/app/models/hackbot/interactions/gifs.rb
+++ b/app/models/hackbot/interactions/gifs.rb
@@ -12,7 +12,7 @@ module Hackbot
         if query.present?
           try_sending_gif(query)
         else
-          msg_channel copy('start.invalid')
+          reply copy('start.invalid')
         end
       end
 
@@ -22,9 +22,9 @@ module Hackbot
         gif = GiphyClient.translate query
 
         if gif.nil?
-          msg_channel copy('start.not_found')
+          reply copy('start.not_found')
         else
-          attach_channel(
+          attach_reply(
             image_url: gif[:url],
             footer: copy('start.valid.text'),
             fallback: copy('start.valid.fallback')

--- a/app/models/hackbot/interactions/help.rb
+++ b/app/models/hackbot/interactions/help.rb
@@ -9,8 +9,8 @@ module Hackbot
       def start
         sorted_cmds = cmds.sort { |a, b| a[:usage] <=> b[:usage] }
 
-        msg_channel copy('help', commands: sorted_cmds,
-                                 bot_mention: '@' + team.bot_username)
+        reply copy('help', commands: sorted_cmds,
+                           bot_mention: '@' + team.bot_username)
       end
 
       private

--- a/app/models/hackbot/interactions/set_poc.rb
+++ b/app/models/hackbot/interactions/set_poc.rb
@@ -11,7 +11,7 @@ module Hackbot
         streak_key = captured[:streak_key]
 
         leader = Leader.find_by(streak_key: streak_key)
-        return msg_channel copy('start.invalid') if leader.nil?
+        return reply copy('start.invalid') if leader.nil?
 
         associate_clubs(leader.clubs, leader)
       end
@@ -22,7 +22,7 @@ module Hackbot
         if valid_club_index_input? club_ids
           handle_club_index_input club_ids
         else
-          msg_channel copy('clubs_num.invalid', num_of_clubs: club_ids.length)
+          reply copy('clubs_num.invalid', num_of_clubs: club_ids.length)
 
           :wait_for_clubs_num
         end
@@ -49,7 +49,7 @@ module Hackbot
       def associate_clubs(clubs, leader)
         if clubs.empty?
           name = pretty_leader_name leader
-          msg_channel copy('start.no_clubs', leader_name: name)
+          reply copy('start.no_clubs', leader_name: name)
 
           :finish
         elsif clubs.length == 1
@@ -74,11 +74,11 @@ module Hackbot
 
         name = pretty_leader_name leader
         if club.save!
-          msg_channel copy('set.success', leader_name: name,
-                                          club_name: club.name)
+          reply copy('set.success', leader_name: name,
+                                    club_name: club.name)
         else
-          msg_channel copy('set.failure', leader_name: name,
-                                          club_name: club.name)
+          reply copy('set.failure', leader_name: name,
+                                    club_name: club.name)
         end
       end
 
@@ -100,16 +100,16 @@ module Hackbot
       # rubocop:disable Metrics/AbcSize
       # rubocop:disable Metrics/MethodLength
       def associate_one_in_many_clubs(clubs, leader)
-        msg_channel copy('start.many_clubs.intro',
+        reply copy('start.many_clubs.intro',
                          leader_name: pretty_leader_name(leader))
 
         clubs.each.with_index(1) do |c, i|
           key = leader.streak_key
-          msg_channel copy('start.many_clubs.each', i: i, club_name: c.name,
-                                                    streak_key: key)
+          reply copy('start.many_clubs.each', i: i, club_name: c.name,
+                                              streak_key: key)
         end
 
-        msg_channel copy('start.many_clubs.outro')
+        reply copy('start.many_clubs.outro')
 
         data['club_ids'] = clubs.map(&:id)
         data['leader_id'] = leader.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
       namespace :webhooks do
         post 'interactive_messages'
         post 'events'
+        post 'slash_command'
       end
     end
   end


### PR DESCRIPTION
This PR begins work on implementing slash commands. I gave up working on this for the time being because actions (read: buttons) inside of slash commands have unintended behavior and break the current logic.

The way this PR implements slash commands is by thinking of `/hackbot` as just another way of saying `@hackbot` inside of a channel. It implements a helper called `reply` that will either send the message to the channel the command was triggered from or to a private, ephemeral message through the `response_url` given by the slash command.

Couple things that need thinking through / changing before this can be merged:

- Mirroring needs to be fixed
- How should multi-step commands be handled? `set-poc` is an example
- Actions currently don't work well. I forget the specific error, but for some reason `update_action_source` wasn't working correctly, if I'm remembering.

Leaving this in a PR as @MaxWofford requested in #188.