### PR TITLE
Don't require username to trigger commands in PMs

### DIFF
--- a/app/models/hackbot/interactions/command.rb
+++ b/app/models/hackbot/interactions/command.rb
@@ -17,7 +17,10 @@ module Hackbot
         trigger = self.class::TRIGGER
         mention_regex = Hackbot::Utterances.name(team)
 
-        msg =~ /^#{mention_regex} #{trigger}$/ && super
+        if in_dm?
+        then msg =~ /^(#{mention_regex} )?#{trigger}$/ && super
+        else msg =~ /^#{mention_regex} #{trigger}$/ && super
+        end
       end
 
       def captured
@@ -30,6 +33,15 @@ module Hackbot
 
       def description
         self.class::DESCRIPTION if self.class.const_defined? 'DESCRIPTION'
+      end
+
+      private
+
+      # Returns whether we're currently in a direct message.
+      #
+      # If the channel ID starts with a D on Slack, then you're in a DM.
+      def in_dm?
+        event[:channel].start_with? 'D'
       end
     end
   end

--- a/lib/data/copy/help.yml
+++ b/lib/data/copy/help.yml
@@ -7,4 +7,4 @@ help: |
     `<%= c[:usage] %>` - <%= c[:desc] %>
     <% end %>
 
-    To use one of them, go ahead and say `<%= bot_mention %>` and then the command you want to run, like `<%= bot_mention %> <%= commands.sample[:usage] %>`.
+    To use one of them, go ahead and say `<%= bot_mention %>` and then the command you want to run, like `<%= bot_mention %> <%= commands.sample[:usage] %>`. You can also PM me a command without mentioning my username, like `<%= commands.sample[:usage] %>`.


### PR DESCRIPTION
This change makes it so you can PM Hackbot commands directly without mentioning its username.

Before:

![recorded](https://cloud.githubusercontent.com/assets/992248/25050329/bdee5a4e-20fb-11e7-9f85-38b30db925ba.gif)

After:

![recorded](https://cloud.githubusercontent.com/assets/992248/25050350/de965f6c-20fb-11e7-9036-25d6f36d0e96.gif)
