### PR TITLE
Put the suggested meeting date button first, if available

### DIFF
--- a/app/models/hackbot/interactions/check_in.rb
+++ b/app/models/hackbot/interactions/check_in.rb
@@ -23,8 +23,6 @@ module Hackbot
         key = 'greeting.' + (first_check_in? ? 'if_first_check_in' : 'default')
         actions = []
 
-        actions << { text: 'Yes' }
-
         if previous_meeting_day
           actions << {
             text: "Yes, on #{previous_meeting_day}",
@@ -32,6 +30,7 @@ module Hackbot
           }
         end
 
+        actions << { text: 'Yes' }
         actions << { text: 'No' }
 
         msg_channel(


### PR DESCRIPTION
This PR makes a super simple UX change that puts the suggested meeting day of week as the first button in the list.

Before:

```
[ Yes ], [ Yes, on Thursday ], [ No ]
```

Now:

```
[ Yes, on Thursday ], [ Yes ], [ No ]
```

Just spoke with a leader about how they'd improve check-ins and this is what they suggested. They accidentally clicked "Yes" when they meant to click "Yes, on Thursday" and all hell broke loose after they quickly tried to click "Yes,  on Thursday" to correct themselves (so some extra events were sent to Hackbot and it tried to process them).

![tmp](https://cloud.githubusercontent.com/assets/992248/25056174/008d29a0-211c-11e7-94fa-6db499174748.png)
