### PR TITLE
Implement `hackbot lookup` command

### DIFF
--- a/app/models/hackbot/dispatcher.rb
+++ b/app/models/hackbot/dispatcher.rb
@@ -6,6 +6,7 @@ module Hackbot
       Hackbot::Interactions::DiceRoll,
       Hackbot::Interactions::Gifs,
       Hackbot::Interactions::Help,
+      Hackbot::Interactions::Lookup,
       Hackbot::Interactions::SetPoc,
       Hackbot::Interactions::Sql,
       Hackbot::Interactions::Stats

--- a/app/models/hackbot/helpers.rb
+++ b/app/models/hackbot/helpers.rb
@@ -18,6 +18,12 @@ module Hackbot
       event[:action]
     end
 
+    # Returns whether the current event being processed is a PM. Slack channel
+    # IDs start with D if they're a private message.
+    def in_pm?
+      event[:channel].starts_with? 'D'
+    end
+
     def current_slack_user
       return nil unless event[:user]
 

--- a/app/models/hackbot/interactions/admin_command.rb
+++ b/app/models/hackbot/interactions/admin_command.rb
@@ -1,0 +1,25 @@
+module Hackbot
+  module Interactions
+    class AdminCommand < Command
+      before_handle :ensure_admin
+
+      protected
+
+      def ensure_admin
+        return if current_admin?
+
+        if state == 'start'
+          msg_channel admin_copy('when_in_start_state')
+        else
+          send_msg(event[:user], admin_copy('when_in_progress'))
+        end
+
+        throw :abort
+      end
+
+      def admin_copy(key, hash = {})
+        copy(key, hash, 'admin_command')
+      end
+    end
+  end
+end

--- a/app/models/hackbot/interactions/lookup.rb
+++ b/app/models/hackbot/interactions/lookup.rb
@@ -1,0 +1,135 @@
+module Hackbot
+  module Interactions
+    class Lookup < Command
+      include ActionView::Helpers::DateHelper
+
+      TRIGGER = /lookup <@(?<uid>.*)>/
+
+      # Quick heads up that &lt; and &gt; are the HTML encodings for < and >,
+      # respectively. Slack requires these characters be HTML encoded.
+      USAGE = 'lookup &lt;@username&gt;'.freeze
+      DESCRIPTION = 'look up a leader and their club from their Slack '\
+                    'username (staff only)'.freeze
+
+      before_handle :ensure_admin
+
+      def start
+        data['uid_to_lookup'] = captured[:uid]
+
+        if in_pm?
+          lookup
+        else
+          msg_channel copy('confirm.msg')
+          :confirm
+        end
+      end
+
+      def confirm
+        return :confirm unless action
+
+        case action[:value]
+        when Hackbot::Utterances.yes
+          send_action_result(copy('confirm.results.proceed'))
+          lookup
+        when Hackbot::Utterances.no
+          send_action_result(copy('confirm.results.cancel'))
+        end
+      end
+
+      private
+
+      def lookup
+        uid = data['uid_to_lookup']
+
+        leader = Leader.find_by(slack_id: uid)
+        return not_found unless leader
+
+        msg_channel construct_msg(leader)
+      end
+
+      def not_found
+        msg_channel copy('not_found')
+      end
+
+      def ensure_admin
+        return if current_admin?
+
+        msg_channel copy('not_admin')
+
+        throw :abort
+      end
+
+      def construct_msg(leader)
+        msg = {
+          text: copy('resp_prefix'),
+          attachments: [
+            construct_leader_attachment(leader),
+            *leader.clubs.map { |c| construct_club_attachment(c) }
+          ]
+        }
+
+        insert_fallbacks!(msg)
+      end
+
+      def construct_leader_attachment(leader)
+        copy(
+          'leader_attachment',
+          color: generate_color(leader.id),
+          leader: leader,
+          leader_icon_url: icon_for_leader(leader),
+          slack: linked_slack(leader.slack_username),
+          github: linked_profile(leader.github_username, 'https://github.com'),
+          twitter:
+            linked_profile(leader.twitter_username, 'https://twitter.com')
+        )
+      end
+
+      def icon_for_leader(leader)
+        info = SlackClient::Users.info(leader.slack_id, access_token)[:user]
+
+        info[:profile][:image_72]
+      end
+
+      def linked_profile(username, url)
+        return nil unless username.present? && url.present?
+
+        "<#{url}/#{username}|#{username}>"
+      end
+
+      def construct_club_attachment(club)
+        color = generate_color(club.id)
+        stats = ClubStatsService.new(club)
+        leaders = club.leaders.map { |l| linked_slack(l.slack_id) }
+        poc = linked_slack(club.point_of_contact.slack_id) if
+          club.point_of_contact.present?
+
+        copy('club_attachment', color: color, club: club, stats: stats,
+                                leaders: leaders, poc: poc)
+      end
+
+      def generate_color(seed)
+        Digest::MD5.hexdigest(seed.to_s)[0, 6]
+      end
+
+      def linked_slack(username_or_id)
+        return nil unless username_or_id.present?
+
+        "<@#{username_or_id}>"
+      end
+
+      # Given a message to be sent to Slack, set N/A as the value for any
+      # attachment fields that aren't present.
+      def insert_fallbacks!(msg)
+        msg[:attachments].each do |attachment|
+          next unless attachment[:fields]
+
+          attachment[:fields].each do |field|
+            field[:value] = 'N/A' unless field[:value].present?
+          end
+        end
+
+        msg
+      end
+    end
+  end
+end

--- a/app/models/hackbot/interactions/lookup.rb
+++ b/app/models/hackbot/interactions/lookup.rb
@@ -1,6 +1,6 @@
 module Hackbot
   module Interactions
-    class Lookup < Command
+    class Lookup < AdminCommand
       include ActionView::Helpers::DateHelper
 
       TRIGGER = /lookup <@(?<uid>.*)>/
@@ -10,8 +10,6 @@ module Hackbot
       USAGE = 'lookup &lt;@username&gt;'.freeze
       DESCRIPTION = 'look up a leader and their club from their Slack '\
                     'username (staff only)'.freeze
-
-      before_handle :ensure_admin
 
       def start
         data['uid_to_lookup'] = captured[:uid]
@@ -49,14 +47,6 @@ module Hackbot
 
       def not_found
         msg_channel copy('not_found')
-      end
-
-      def ensure_admin
-        return if current_admin?
-
-        msg_channel copy('not_admin')
-
-        throw :abort
       end
 
       def construct_msg(leader)

--- a/app/models/hackbot/interactions/lookup.rb
+++ b/app/models/hackbot/interactions/lookup.rb
@@ -6,7 +6,8 @@ module Hackbot
       TRIGGER = /lookup <@(?<uid>.*)>/
 
       # Quick heads up that &lt; and &gt; are the HTML encodings for < and >,
-      # respectively. Slack requires these characters be HTML encoded.
+      # respectively. If we don't HTML encode them, Slack will interpret
+      # @username as a mention.
       USAGE = 'lookup &lt;@username&gt;'.freeze
       DESCRIPTION = 'look up a leader and their club from their Slack '\
                     'username (staff only)'.freeze

--- a/app/models/hackbot/interactions/set_poc.rb
+++ b/app/models/hackbot/interactions/set_poc.rb
@@ -1,13 +1,11 @@
 module Hackbot
   module Interactions
-    class SetPoc < Command
+    class SetPoc < AdminCommand
       TRIGGER = /set-poc ?(?<streak_key>.+)/
 
       USAGE = 'set-poc <leader_streak_key>'.freeze
       DESCRIPTION = 'set the given leader as the point of contact for their '\
                     'club (staff only)'.freeze
-
-      before_handle :ensure_admin
 
       def start
         streak_key = captured[:streak_key]
@@ -129,14 +127,6 @@ module Hackbot
 
       def get_last_arg(text)
         text.split(' ').last
-      end
-
-      def ensure_admin
-        return if current_admin?
-
-        msg_channel(copy('not_admin'))
-
-        throw :abort
       end
     end
   end

--- a/app/models/hackbot/interactions/sql.rb
+++ b/app/models/hackbot/interactions/sql.rb
@@ -76,14 +76,12 @@ end
 
 module Hackbot
   module Interactions
-    class Sql < Command
+    class Sql < AdminCommand
       TRIGGER = /sql (?<query>.*)/
 
       USAGE = 'sql <query>'.freeze
       DESCRIPTION = 'execute the given SQL query and return the results '\
                     '(staff only)'.freeze
-
-      before_handle :ensure_admin
 
       def start
         data['query'] = captured[:query]
@@ -118,18 +116,6 @@ module Hackbot
       # Convert the given string to a formatted Slack code block.
       def to_code(str)
         "```\n" + str + "\n```"
-      end
-
-      def ensure_admin
-        return if current_admin?
-
-        if state == 'start'
-          msg_channel copy('not_admin_start')
-        else
-          send_msg(event[:user], copy('not_admin_in_progress'))
-        end
-
-        throw :abort
       end
     end
   end

--- a/app/models/hackbot/slack_interaction.rb
+++ b/app/models/hackbot/slack_interaction.rb
@@ -3,7 +3,7 @@ module Hackbot
     extend ActiveSupport::Concern
 
     def send_msg(channel, msg)
-      opts = { as_user: true }
+      opts = HashWithIndifferentAccess.new(as_user: true)
 
       if msg.is_a? String
         opts[:text] = msg

--- a/app/services/club_stats_service.rb
+++ b/app/services/club_stats_service.rb
@@ -31,7 +31,7 @@ class ClubStatsService
 
   def meeting_count
     # We can't just do @club.check_ins because multiple check-ins can exist for
-    # a single date (like in the case when we were polling every leader ever
+    # a single date (like in the case when we were polling every leader every
     # week).
     #
     # This counts the number of unique meeting dates that are present in the

--- a/app/services/club_stats_service.rb
+++ b/app/services/club_stats_service.rb
@@ -1,0 +1,53 @@
+# This is a more generic version of StatsService that provides general
+# "interesting insights" into activity of clubs.
+#
+# This was originally created when implementing Hackbot::Interactions::Lookup
+# and running into hurdles using StatsService directly (namely, StatsService
+# requires starting with a leader, where this service works with club objects
+# directly).
+class ClubStatsService
+  include ActionView::Helpers::DateHelper
+
+  def initialize(club)
+    @club = club
+  end
+
+  def last_meeting_date
+    return nil if @club.check_ins.empty?
+
+    ordered_check_ins.last.meeting_date
+  end
+
+  def last_meeting_attendance
+    return nil if @club.check_ins.empty?
+
+    # Need to do this instead of just doing ordered_check_ins because there can
+    # be multiple check-ins for a single meeting date.
+    CheckIn.where(
+      club: @club,
+      meeting_date: last_meeting_date
+    ).average(:attendance).to_i
+  end
+
+  def meeting_count
+    # We can't just do @club.check_ins because multiple check-ins can exist for
+    # a single date (like in the case when we were polling every leader ever
+    # week).
+    #
+    # This counts the number of unique meeting dates that are present in the
+    # club's check-ins.
+    @club.check_ins.select(:meeting_date).distinct.count
+  end
+
+  def average_attendance
+    return nil if @club.check_ins.empty?
+
+    @club.check_ins.average(:attendance).to_i
+  end
+
+  private
+
+  def ordered_check_ins
+    @club.check_ins.order(:meeting_date)
+  end
+end

--- a/app/services/copy_service.rb
+++ b/app/services/copy_service.rb
@@ -5,9 +5,16 @@ class CopyService
   end
 
   def get_copy(key)
-    erb = ERB.new get_erb(key)
+    to_render = get_erb(key)
 
-    erb.result @context
+    if to_render.is_a? String
+      ERB.new(to_render).result(@context)
+    else
+      to_render = to_render.to_yaml
+      rendered = ERB.new(to_render).result(@context)
+
+      HashWithIndifferentAccess.new(YAML.load(rendered))
+    end
   end
 
   def get_erb(key)
@@ -16,8 +23,8 @@ class CopyService
 
     sections.each { |s| copy = copy[s] }
 
-    # If there are multiple options, choose one at random.
-    copy.respond_to?('each') ? copy.sample : copy
+    # If we get an array, choose one element at random.
+    copy.is_a?(Array) ? copy.sample : copy
   end
 
   private

--- a/app/services/copy_service.rb
+++ b/app/services/copy_service.rb
@@ -1,4 +1,7 @@
 class CopyService
+  # Make ActionView helpers available in copy files when renderings
+  include ActionView::Helpers
+
   def initialize(interaction_name, hash)
     @interaction_name = interaction_name
     @context = hash_to_binding hash

--- a/lib/data/copy/admin_command.yml
+++ b/lib/data/copy/admin_command.yml
@@ -1,0 +1,2 @@
+when_in_start_state: You must be an administrator to use this command.
+when_in_progress: You must be an administrator to interact with this command.

--- a/lib/data/copy/lookup.yml
+++ b/lib/data/copy/lookup.yml
@@ -1,0 +1,102 @@
+not_admin: You must be an admin to use this command.
+not_found: Unable to find a leader with that username.
+
+confirm:
+  msg:
+    text: |
+      Are you sure you want me to do this lookup here? Doing so will make the results of the lookup, which will include private info, available to everyone in the channel.
+
+      *This will share private info. Be careful.*
+    attachments:
+      - actions:
+          - text: 'Yes'
+          - text: 'No'
+  results:
+    proceed: ':white_check_mark: *Do the lookup*'
+    cancel: ':no_entry: *Do not do the lookup*'
+
+resp_prefix: "Here's what I found:"
+leader_attachment:
+  author_icon: '<%= leader_icon_url %>'
+  author_name: '<%= leader.name %>'
+  color: '<%= color %>'
+  fields:
+    - title: Email
+      value: '<%= leader.email %>'
+      short: false
+    - title: Slack Username
+      value: '<%= slack %>'
+      short: true
+    - title: GitHub Username
+      value: '<%= github %>'
+      short: true
+    - title: Twitter Username
+      value: '<%= twitter %>'
+      short: true
+    - title: Phone Number
+      value: '<%= leader.phone_number %>'
+      short: true
+    - title: Gender
+      value: '<%= leader.gender %>'
+      short: true
+    - title: Graduation Year
+      value: '<%= leader.year %>'
+      short: true
+    - title: Address
+      value: '<%= leader.address %>'
+      short: false
+    - title: Streak Key
+      value: '<%= leader.streak_key %>'
+      short: true
+    - title: Database ID
+      value: '<%= leader.id %>'
+      short: true
+    - title: Created
+      value: '<%= time_ago_in_words leader.created_at %> ago'
+      short: true
+    - title: Last Updated
+      value: '<%= time_ago_in_words leader.updated_at %> ago'
+      short: true
+    - title: Notes
+      value: '<%= leader.notes %>'
+      short: false
+club_attachment:
+  # Quick word of warning: I have U+2063 after that \n to force Slack to not
+  # strip the extra new line. For some reason, the message looks *way* better
+  # when there's a new line after the club's name.
+  text: "_*<%= club.name %>*_\n⁣"
+  color: '<%= color %>'
+  fields:
+    - title: Last Meeting
+      value: '<%= stats.last_meeting_date %>'
+      short: true
+    - title: '# Meetings'
+      value: '<%= stats.meeting_count %>'
+      short: true,
+    - title: Average Attendance
+      value: '<%= stats.average_attendance %>'
+      short: true,
+    - title: Leadership Team
+      value: "<%= leaders.join(', ') %>"
+      short: true,
+    - title: Point of Contact
+      value: '<%= poc %>'
+      short: true,
+    - title: Address
+      value: '<%= club.address %>'
+      short: false,
+    - title: Streak Key
+      value: '<%= club.streak_key %>'
+      short: true,
+    - title: Database ID
+      value: '<%= club.id %>'
+      short: true,
+    - title: Created
+      value: '<%= time_ago_in_words club.created_at %> ago'
+      short: true,
+    - title: Last Updated
+      value: '<%= time_ago_in_words club.updated_at %> ago'
+      short: true,
+    - title: Notes
+      value: '<%= club.notes %>'
+      short: false

--- a/lib/data/copy/lookup.yml
+++ b/lib/data/copy/lookup.yml
@@ -1,4 +1,3 @@
-not_admin: You must be an admin to use this command.
 not_found: Unable to find a leader with that username.
 
 confirm:

--- a/lib/data/copy/set_poc.yml
+++ b/lib/data/copy/set_poc.yml
@@ -1,4 +1,3 @@
-not_admin: You must be an administrator to use this command.
 start:
     invalid: I can't find that leader :-?
     no_clubs: <%= leader_name %> is not associated with any clubs.

--- a/lib/data/copy/sql.yml
+++ b/lib/data/copy/sql.yml
@@ -1,5 +1,3 @@
-not_admin_start: You must be an administrator to use this command.
-not_admin_in_progress: You must be an administrator to interact with this command.
 confirm:
   text: |
     Are you sure? This will execute `<%= query %>` and return the results publicly to this channel.


### PR DESCRIPTION
These changes do three things:

1. Allow you to get objects outside of the copy system (see [here](https://github.com/hackclub/api/blob/6cdb2bf20a3b5c6dd7ff1d39175286c8528cf8b4/lib/data/copy/lookup.yml#L3-L15) for an example, it's surprisingly nice for Slack messages that include actions). If this is merged, our copy system is turning more into a view system. Might be worth more discussion around making it a view system at some point?
2. Allow you to look up a leader and details on their clubs with `hackbot lookup @slack_username`. Surprisingly nice for getting context on who people are, I've been playing around with it all day and been pleasantly surprised.
3. Refactor all this admin logic that's been being implemented into a class called `AdminCommand`. Want a command to only work for the admin gods? Make it a subclass of `AdminCommand`.

![recorded](https://cloud.githubusercontent.com/assets/992248/25060255/b64f616e-214d-11e7-9bd7-593e09219fe4.gif)

There's a confirmation before a lookup runs if you trigger it outside of a PM:

![recorded](https://cloud.githubusercontent.com/assets/992248/25060266/ed6607a2-214d-11e7-8609-3d55157598fc.gif)

It's not showing any clubs for Max because he isn't associated with any. Here's what it looks like if you have clubs:

![recorded](https://cloud.githubusercontent.com/assets/992248/25060291/4ad51d4c-214e-11e7-89f2-4ee8875edefc.gif)
