### PR TITLE
Remove unused bin/delayed_job

### DIFF
--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -1,6 +1,0 @@
-#!/usr/bin/env ruby
-
-require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config',
-                                   'environment'))
-require 'delayed/command'
-Delayed::Command.new(ARGV).daemonize


### PR DESCRIPTION
This change removes `bin/delayed_job` because we're using `rails jobs:work` to invoke our worker instead. Occam's Razor, yo.

If we wanted to use `bin/delayed_job`, we'd have to install the `daemons` gem anyways. See https://github.com/collectiveidea/delayed_job#running-jobs.