### PR TITLE
Unescape HTML escaped event text

### DIFF
--- a/app/controllers/v1/hackbot/webhooks_controller.rb
+++ b/app/controllers/v1/hackbot/webhooks_controller.rb
@@ -47,6 +47,10 @@ module V1
       private
 
       def handle_event(event, team_id)
+        # Slack HTML escapes the '>', '<', and '&' characters. This unescapes
+        # them.
+        event[:text] = CGI.unescapeHTML(event[:text]) if event[:text]
+
         HandleSlackEventJob.perform_later(event, team_id)
       end
 


### PR DESCRIPTION
Slack HTML escapes the `>`, `<`, and `&` characters. This was causing unexpected behavior with `hackbot sql`, where queries like `SELECT id, name FROM leaders WHERE created_at > current_date - interval '7 days'` weren't working because Slack would replace `>` with `&gt;`.

With this change, `event[:text]` will include the text as the user typed it (except for when the user @mentions someone or sends a link).