### PR TITLE
Set state to :finish when denying an interaction to a non-admin

### DIFF
--- a/app/models/hackbot/interactions/admin_command.rb
+++ b/app/models/hackbot/interactions/admin_command.rb
@@ -10,6 +10,8 @@ module Hackbot
 
         if state == 'start'
           msg_channel admin_copy('when_in_start_state')
+
+          self.state = :finish
         else
           send_msg(event[:user], admin_copy('when_in_progress'))
         end


### PR DESCRIPTION
Fixes the issue @ItsDaGeek found in https://hackclub.slack.com/files/jrc/F507T35A9/pasted_image_at_2017_04_17_10_02_am.png.