### PR TITLE
Use pagination for StreakClient::Box.all_in_pipeline

### DIFF
--- a/lib/streak_client/box.rb
+++ b/lib/streak_client/box.rb
@@ -4,13 +4,16 @@ module StreakClient
       StreakClient.request(:get, '/v1/boxes')
     end
 
-    def self.all_in_pipeline(pipeline_key, chunk_size = 50)
+    def self.all_in_pipeline(pipeline_key, chunk_size = 50, cache_time = 5.minutes)
       Enumerator.new do |y|
         page = 0
 
         loop do
-          resp = all_in_pipeline_paginated(pipeline_key, page: page,
-                                           limit: chunk_size)
+          key = "all_in_pipeline##{pipeline_key}##{page}##{chunk_size}"
+          resp = Rails.cache.fetch(key, expires_in: cache_time) do
+            all_in_pipeline_paginated(pipeline_key, page: page,
+                                      limit: chunk_size)
+          end
 
           resp[:results].each { |r| y << r }
 

--- a/lib/streak_client/box.rb
+++ b/lib/streak_client/box.rb
@@ -5,13 +5,19 @@ module StreakClient
     end
 
     def self.all_in_pipeline(pipeline_key)
-      StreakClient.request(
-        :get,
-        "/v1/pipelines/#{pipeline_key}/boxes",
-        {},  # params
-        {},  # headers
-        true # cache
-      )
+      results = []
+      page = 0
+      more_results = true
+
+      while more_results
+        resp = all_in_pipeline_paginated(pipeline_key, page: page, limit: 50)
+        results += resp[:results]
+        more_results = resp[:has_next_page]
+
+        page += 1
+      end
+
+      results
     end
 
     def self.all_in_pipeline_paginated(pipeline_key, page:, limit:)

--- a/lib/streak_client/box.rb
+++ b/lib/streak_client/box.rb
@@ -4,16 +4,13 @@ module StreakClient
       StreakClient.request(:get, '/v1/boxes')
     end
 
-    def self.all_in_pipeline(pipeline_key, chunk_size = 50, cache_time = 5.minutes)
+    def self.all_in_pipeline(pipeline_key, chunk_size = 1000)
       Enumerator.new do |y|
         page = 0
 
         loop do
-          key = "all_in_pipeline##{pipeline_key}##{page}##{chunk_size}"
-          resp = Rails.cache.fetch(key, expires_in: cache_time) do
-            all_in_pipeline_paginated(pipeline_key, page: page,
-                                      limit: chunk_size)
-          end
+          resp = all_in_pipeline_paginated(pipeline_key, page: page,
+                                                         limit: chunk_size)
 
           resp[:results].each { |r| y << r }
 
@@ -28,8 +25,12 @@ module StreakClient
       StreakClient.request(
         :get,
         "/v2/pipelines/#{pipeline_key}/boxes",
-        page: page,
-        limit: limit
+        {
+          page: page,
+          limit: limit
+        },
+        {},
+        true
       )
     end
 

--- a/lib/streak_client/box.rb
+++ b/lib/streak_client/box.rb
@@ -4,20 +4,21 @@ module StreakClient
       StreakClient.request(:get, '/v1/boxes')
     end
 
-    def self.all_in_pipeline(pipeline_key)
-      results = []
-      page = 0
-      more_results = true
+    def self.all_in_pipeline(pipeline_key, chunk_size = 50)
+      Enumerator.new do |y|
+        page = 0
 
-      while more_results
-        resp = all_in_pipeline_paginated(pipeline_key, page: page, limit: 50)
-        results += resp[:results]
-        more_results = resp[:has_next_page]
+        loop do
+          resp = all_in_pipeline_paginated(pipeline_key, page: page,
+                                           limit: chunk_size)
 
-        page += 1
+          resp[:results].each { |r| y << r }
+
+          break unless resp[:has_next_page]
+
+          page += 1
+        end
       end
-
-      results
     end
 
     def self.all_in_pipeline_paginated(pipeline_key, page:, limit:)


### PR DESCRIPTION
This PR changes the way in which `StreakClient::Box.all_in_pipeline` retrieves it's boxes. Previously it pulled down the entire pipeline at once through the v1 API, which *sometimes caused 500 errors* and was very slow. Now, we use pagination (ie. the v2 API).

This should be good to merge as it is, and not effect the performance of our application too much – but I do want to consider caching this function just to make everything as quick as possible.

If we do decide to cache, what would this look like? Caching the individual network requests seems like a bad idea prone to error. Does that mean we just cache at a function level?

Would love your thoughts @MaxWofford.