### PR TITLE
Update the way we handle letter box creation

### DIFF
--- a/app/controllers/v1/leaders_controller.rb
+++ b/app/controllers/v1/leaders_controller.rb
@@ -10,7 +10,6 @@ module V1
       )
 
       if leader.save
-        welcome_letter_for_leader(leader).save!
         welcome_to_slack leader
 
         render json: leader, status: 201
@@ -34,17 +33,6 @@ module V1
       params.permit(
         :name, :email, :gender, :year, :phone_number, :slack_username,
         :github_username, :twitter_username, :address
-      )
-    end
-
-    def welcome_letter_for_leader(leader)
-      Letter.new(
-        name: leader.name,
-        # This is the type for club leaders
-        letter_type: '9002',
-        # This is the type for welcome letter + 3oz of stickers
-        what_to_send: '9005',
-        address: leader.address
       )
     end
 

--- a/app/models/hackbot/interactions/set_poc.rb
+++ b/app/models/hackbot/interactions/set_poc.rb
@@ -1,5 +1,6 @@
 module Hackbot
   module Interactions
+    # rubocop:disable Metrics/ClassLength
     class SetPoc < AdminCommand
       TRIGGER = /set-poc ?(?<streak_key>.+)/
 
@@ -32,6 +33,8 @@ module Hackbot
         end
       end
 
+      # rubocop:disable Metrics/MethodLength
+      # rubocop:disable Metrics/AbcSize
       def wait_for_letter_decision
         leader = Leader.find data['leader_id']
         name = pretty_leader_name leader
@@ -48,6 +51,8 @@ module Hackbot
           :wait_for_letter_decision
         end
       end
+      # rubocop:enable Metrics/MethodLength
+      # rubocop:enable Metrics/AbcSize
 
       private
 
@@ -112,11 +117,6 @@ module Hackbot
         set_poc club, leader
       end
 
-      # Disabling rubocop here because it's ruling that this method doesn't make
-      # any sense.
-      #
-      # rubocop:disable Metrics/AbcSize
-      # rubocop:disable Metrics/MethodLength
       def associate_one_in_many_clubs(clubs, leader)
         msg_channel copy('start.many_clubs.intro',
                          leader_name: pretty_leader_name(leader))
@@ -133,8 +133,6 @@ module Hackbot
 
         :wait_for_clubs_num
       end
-      # rubocop:enable Metrics/AbcSize
-      # rubocop:enable Metrics/MethodLength
 
       def create_welcome_letter_box(leader)
         Letter.new(
@@ -157,5 +155,6 @@ module Hackbot
         text.split(' ').last
       end
     end
+    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/app/services/copy_service.rb
+++ b/app/services/copy_service.rb
@@ -12,7 +12,7 @@ class CopyService
 
     rendered = recursive_render to_render
 
-    if rendered.is_a? String
+    if rendered.is_a?(String) || rendered.is_a?(Array)
       rendered
     else
       HashWithIndifferentAccess.new(rendered)
@@ -36,11 +36,25 @@ class CopyService
 
     sections.each { |s| copy = copy[s] }
 
-    # If we get an array, choose one element at random.
-    copy.is_a?(Array) ? copy.sample : copy
+    # If we get an array of strings, choose one element at random.
+    array_of_strings?(copy) ? copy.sample : copy
   end
 
   private
+
+  def array_of_strings?(arr)
+    return unless arr.is_a? Array
+
+    all_strings = true
+    arr.each |a| do
+      next if a.is_a? String
+
+      all_strings = false
+      break
+    end
+
+    all_strings
+  end
 
   def get_interaction_yaml(name)
     path = File.join(copy_route, "#{name}.yml")

--- a/app/services/copy_service.rb
+++ b/app/services/copy_service.rb
@@ -46,7 +46,7 @@ class CopyService
     return unless arr.is_a? Array
 
     all_strings = true
-    arr.each |a| do
+    arr.each do |a|
       next if a.is_a? String
 
       all_strings = false

--- a/lib/data/copy/set_poc.yml
+++ b/lib/data/copy/set_poc.yml
@@ -9,8 +9,17 @@ clubs_num:
     invalid: Please choose a number between 1 and <%= num_of_clubs %>
 set:
     success: <%= leader_name %> has been associated with <%= club_name %>. Would you like to send a welcome letter to them?
+    actions:
+        - text: Send a welcome letter
+          value: 'yes'
+        - text: Don't send a letter
+          value: 'no'
     failure: Unable to associate <%= leader_name %> with <%= club_name %>
 letter_decision:
-    affirmative: Right on! A letter will be sent to <%= leader_name %>.
-    negative: Alright then. <%= leader_name %> won't be sent a letter.
+    affirmative:
+        text: Aaaaannddd sent. Thanks!
+        action_result: ":envelope: Sending a welcome letter to <%= leader_name %>!"
+    negative:
+        action_result: ":no_entry: Not sending a welcome letter to <%= leader_name %>."
+        text: Alright then.
     invalid: I didn't quite understand what you just said. Would you mind repeating that, with either "yes" or "no" as an answer?

--- a/lib/data/copy/set_poc.yml
+++ b/lib/data/copy/set_poc.yml
@@ -8,5 +8,9 @@ start:
 clubs_num:
     invalid: Please choose a number between 1 and <%= num_of_clubs %>
 set:
-    success: <%= leader_name %> has been associated with <%= club_name %>
+    success: <%= leader_name %> has been associated with <%= club_name %>. Would you like to send a welcome letter to them?
     failure: Unable to associate <%= leader_name %> with <%= club_name %>
+letter_decision:
+    affirmative: Right on! A letter will be sent to <%= leader_name %>.
+    negative: Alright then. <%= leader_name %> won't be sent a letter.
+    invalid: I didn't quite understand what you just said. Would you mind repeating that, with either "yes" or "no" as an answer?

--- a/spec/requests/v1/leaders_spec.rb
+++ b/spec/requests/v1/leaders_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe 'V1::Leaders', type: :request do
     end
 
     context 'with valid attributes' do
-      let!(:starting_letter_count) { Letter.count }
       let(:welcome) do
         class_double(Hackbot::Interactions::Welcome).as_stubbed_const
       end
@@ -55,11 +54,6 @@ RSpec.describe 'V1::Leaders', type: :request do
         club_json = JSON.parse(club.to_json)
 
         expect(json['clubs']).to eq([club_json])
-      end
-
-      it 'creates a letter for the leader' do
-        expect(Letter.count).to eq(starting_letter_count + 1)
-        expect(Letter.last.name).to eq(req_body[:name])
       end
     end
 


### PR DESCRIPTION
Last week we had a meeting which decreed that letters shall only be
created for POCs to ensure that we can not fall behind and create a
massive backlog.