### PR TITLE
Implement club ownership

### DIFF
--- a/app/controllers/v1/new_clubs_controller.rb
+++ b/app/controllers/v1/new_clubs_controller.rb
@@ -10,6 +10,11 @@ module V1
       render_success NewClub.all
     end
 
+    # list owned clubs
+    def index_owned
+      render_success current_user.owned_clubs
+    end
+
     def show
       club = NewClub.find(params[:id])
       authorize club

--- a/app/controllers/v1/new_clubs_controller.rb
+++ b/app/controllers/v1/new_clubs_controller.rb
@@ -21,7 +21,7 @@ module V1
       club = NewClub.find(params[:id])
       authorize club
 
-      if club.update_attributes(club_params)
+      if club.update_attributes(club_params(club))
         render_success club
       else
         render_field_errors club.errors
@@ -38,15 +38,8 @@ module V1
 
     private
 
-    def club_params
-      params.permit(
-        :high_school_name,
-        :high_school_type,
-        :high_school_address,
-        :high_school_start_month,
-        :high_school_end_month,
-        :club_website
-      )
+    def club_params(club)
+      params.permit(policy(club).permitted_attributes)
     end
   end
 end

--- a/app/models/new_club.rb
+++ b/app/models/new_club.rb
@@ -5,6 +5,8 @@ class NewClub < ApplicationRecord
 
   scope :dead, -> { where.not(died_at: nil) }
 
+  belongs_to :owner, class_name: 'User'
+
   has_many :new_club_applications
 
   has_many :leadership_positions

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,11 @@ class User < ApplicationRecord
   belongs_to :new_leader
   has_many :leadership_position_invites
 
+  has_many :owned_clubs,
+           class_name: 'NewClub',
+           foreign_key: 'owner_id',
+           inverse_of: :owner
+
   after_initialize :default_values
   before_validation :downcase_email
   before_create :set_username_if_unset

--- a/app/policies/new_club_policy.rb
+++ b/app/policies/new_club_policy.rb
@@ -1,6 +1,21 @@
 # frozen_string_literal: true
 
 class NewClubPolicy < ApplicationPolicy
+  def permitted_attributes
+    attrs = %i[
+      high_school_name
+      high_school_type
+      high_school_address
+      high_school_start_month
+      high_school_end_month
+      club_website
+    ]
+
+    attrs << :owner_id if user.admin?
+
+    attrs
+  end
+
   def show?
     user.admin? || holds_leadership_position?
   end

--- a/app/serializers/new_club_serializer.rb
+++ b/app/serializers/new_club_serializer.rb
@@ -22,6 +22,7 @@ class NewClubSerializer < ActiveModel::Serializer
              :high_school_end_month,
              :club_website
 
+  belongs_to :owner
   has_many :new_leaders
   has_many :leadership_positions
   has_many :leadership_position_invites

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,8 @@ Rails.application.routes.draw do
 
     resources :new_clubs, only: %i[index show update] do
       collection do
+        get 'owned', to: 'new_clubs#index_owned'
+
         scope module: 'new_clubs' do
           resources :information_verification_requests, only: [] do
             post 'verify'

--- a/db/migrate/20180618204143_add_owner_to_new_clubs.rb
+++ b/db/migrate/20180618204143_add_owner_to_new_clubs.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOwnerToNewClubs < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :new_clubs, :owner, foreign_key: { to_table: :users }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_15_042444) do
+ActiveRecord::Schema.define(version: 2018_06_18_204143) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -503,7 +503,9 @@ ActiveRecord::Schema.define(version: 2018_06_15_042444) do
     t.integer "high_school_start_month"
     t.integer "high_school_end_month"
     t.text "club_website"
+    t.bigint "owner_id"
     t.index ["died_at"], name: "index_new_clubs_on_died_at"
+    t.index ["owner_id"], name: "index_new_clubs_on_owner_id"
   end
 
   create_table "new_clubs_information_verification_requests", force: :cascade do |t|
@@ -667,6 +669,7 @@ ActiveRecord::Schema.define(version: 2018_06_15_042444) do
   add_foreign_key "net_promoter_score_surveys", "leaders"
   add_foreign_key "new_club_applications", "new_clubs"
   add_foreign_key "new_club_applications", "users", column: "point_of_contact_id"
+  add_foreign_key "new_clubs", "users", column: "owner_id"
   add_foreign_key "new_clubs_information_verification_requests", "new_clubs"
   add_foreign_key "new_clubs_information_verification_requests", "users", column: "verifier_id"
   add_foreign_key "notes", "users"

--- a/spec/models/new_club_spec.rb
+++ b/spec/models/new_club_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe NewClub, type: :model do
   it { should have_db_column :created_at }
   it { should have_db_column :updated_at }
   it { should have_db_column :died_at }
+  it { should have_db_column :owner_id }
   it { should have_db_column :high_school_name }
   it { should have_db_column :high_school_url }
   it { should have_db_column :high_school_type }
@@ -34,6 +35,8 @@ RSpec.describe NewClub, type: :model do
   it { should define_enum_for :high_school_type }
 
   ## associations ##
+
+  it { should belong_to :owner }
 
   it { should have_many(:new_club_applications) }
   it { should have_many(:leadership_positions) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -85,6 +85,7 @@ RSpec.describe User, type: :model do
   it { should have_many(:leadership_position_invites) }
   it { should have_many(:leader_profiles) }
   it { should have_many(:new_club_applications).through(:leader_profiles) }
+  it { should have_many(:owned_clubs) }
 
   it 'properly sets default values' do
     expect(User.new.email_on_new_challenges).to eq(false)

--- a/spec/requests/v1/new_clubs_spec.rb
+++ b/spec/requests/v1/new_clubs_spec.rb
@@ -124,11 +124,13 @@ RSpec.describe 'V1::NewClubs', type: :request do
 
   describe 'PATCH /v1/new_clubs/:id' do
     let(:club) { create(:new_club) }
+    let(:owner) { create(:user) }
 
     let(:method) { :patch }
     let(:url) { "/v1/new_clubs/#{club.id}" }
     let(:params) do
       {
+        owner_id: owner.id,
         high_school_name: 'Sample School',
         high_school_type: :private_school,
         high_school_address: 'Fake Street, NYC',
@@ -163,6 +165,10 @@ RSpec.describe 'V1::NewClubs', type: :request do
             'high_school_end_month' => 4,
             'club_website' => 'https://example.com'
           )
+          expect(json['owner']).to include(
+            'id' => owner.id,
+            'username' => owner.username
+          )
         end
 
         context 'with invalid params' do
@@ -182,8 +188,9 @@ RSpec.describe 'V1::NewClubs', type: :request do
       context 'with leadership position' do
         let(:setup) { club.new_leaders << create(:new_leader, user: user) }
 
-        it 'succeeds' do
+        it 'succeeds, but does not update owner' do
           expect(response.status).to eq(200)
+          expect(json).to include('owner' => nil)
         end
       end
     end

--- a/spec/requests/v1/new_clubs_spec.rb
+++ b/spec/requests/v1/new_clubs_spec.rb
@@ -54,6 +54,34 @@ RSpec.describe 'V1::NewClubs', type: :request do
     end
   end
 
+  describe 'GET /v1/new_clubs/owned' do
+    let(:method) { :get }
+    let(:url) { '/v1/new_clubs/owned' }
+
+    it 'requires authentication' do
+      expect(response.status).to eq(401)
+    end
+
+    context 'when authenticated' do
+      let(:user) { create(:user_authed) }
+      let(:headers) { auth_headers }
+
+      it "doesn't list any clubs" do
+        expect(response.status).to eq(200)
+        expect(json.length).to eq(0)
+      end
+
+      context 'with associated clubs' do
+        let(:setup) { create_list(:new_club, 3, owner: user) }
+
+        it 'lists all clubs' do
+          expect(response.status).to eq(200)
+          expect(json.length).to eq(3)
+        end
+      end
+    end
+  end
+
   describe 'GET /v1/new_clubs/:id' do
     let(:club) { create(:new_club) }
 


### PR DESCRIPTION
Introduces the concept of ownership to NewClubs. An owner is the person from staff responsible for the club's success, like myself or @MaxWofford.

- Adds the `owner` field to NewClubs
- PATCH `owner_id` to `/v1/new_clubs/:id` to set the owner of a club. Owners are users, so the `owner_id` should be the ID of the user to make the owner.
- GET `/v1/new_clubs/owned` to get a list of all of the current user's owned clubs

Note: this doesn't set up all of the permissions correctly, I'll have to fix and add that as issues arise.