### PR TITLE
Keep same auth token unless older than 3 days

### DIFF
--- a/app/controllers/v1/users_controller.rb
+++ b/app/controllers/v1/users_controller.rb
@@ -43,7 +43,7 @@ module V1
          user.login_code == login_code &&
          user.login_code_generation > (Time.current - 15.minutes)
 
-        user.generate_auth_token!
+        user.generate_or_keep_auth_token
         user.login_code = nil
         user.login_code_generation = nil
         user.save

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -116,7 +116,7 @@ class User < ApplicationRecord
   end
 
   def generate_or_keep_auth_token
-    generate_auth_token! if auth_token_generation > (Time.current - 3.days)
+    generate_auth_token! if self.auth_token_generation > (Time.current - 3.days)
   end
 
   def make_admin!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -116,9 +116,7 @@ class User < ApplicationRecord
   end
 
   def generate_or_keep_auth_token
-    if self.auth_token_generation > (Time.current - 3.days)
-      self.generate_auth_token!
-    end
+    generate_auth_token! if auth_token_generation > (Time.current - 3.days)
   end
 
   def make_admin!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -115,6 +115,12 @@ class User < ApplicationRecord
     end
   end
 
+  def generate_or_keep_auth_token
+    if self.auth_token_generation > (Time.current - 3.days)
+      self.generate_auth_token!
+    end
+  end
+
   def make_admin!
     self.admin_at = Time.current
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -116,7 +116,11 @@ class User < ApplicationRecord
   end
 
   def generate_or_keep_auth_token
-    generate_auth_token! if self.auth_token_generation > (Time.current - 3.days)
+    if auth_token_generation.nil?
+      generate_auth_token!
+    elsif auth_token_generation > (Time.current - 3.days)
+      generate_auth_token!
+    end
   end
 
   def make_admin!


### PR DESCRIPTION
When you login to a Hack Club app, you generate a new auth token each time, forcefully logging you out of the one that you were using before.

This PR fixes that by issuing the same auth token as a previous login (assuming that you're under the 3 day timeout)

There are probably better ways to do this (see: there's no way to invalidate a current token now), but I wanted to get this open.