### PR TITLE
Revert "Keep same auth token unless older than 3 days"

### DIFF
--- a/app/controllers/v1/users_controller.rb
+++ b/app/controllers/v1/users_controller.rb
@@ -43,7 +43,7 @@ module V1
          user.login_code == login_code &&
          user.login_code_generation > (Time.current - 15.minutes)
 
-        user.generate_or_keep_auth_token
+        user.generate_auth_token!
         user.login_code = nil
         user.login_code_generation = nil
         user.save

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -115,14 +115,6 @@ class User < ApplicationRecord
     end
   end
 
-  def generate_or_keep_auth_token
-    if auth_token_generation.nil?
-      generate_auth_token!
-    elsif auth_token_generation > (Time.current - 3.days)
-      generate_auth_token!
-    end
-  end
-
   def make_admin!
     self.admin_at = Time.current
   end


### PR DESCRIPTION
Reverts hackclub/api#398

We think this led to a weird authentication error with Bank customers, and until we root-cause it we should rollback changes. Will take another look this week.