### PR TITLE
Adds release command to auto migrate db

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: bin/rails server -p $PORT -e $RAILS_ENV
 worker: bundle exec sidekiq
+release: bin/release-tasks

--- a/bin/release-tasks
+++ b/bin/release-tasks
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [ "$DISABLE_RAILS_DB_MIGRATIONS" = "true" ]; then
+  echo "SKIPPING DATABASE MIGRATIONS"
+else
+  bundle exec rake db:migrate
+fi


### PR DESCRIPTION
Add an automatic db migration command so we don't have to freak out and race to run the DB migration command whenever we make a DB change